### PR TITLE
Domain-aware email normalization (StripDots) + subaddress separator parsing

### DIFF
--- a/modules/general/core/src/main/scala/oxygen/core/model/Email.scala
+++ b/modules/general/core/src/main/scala/oxygen/core/model/Email.scala
@@ -7,27 +7,98 @@ import oxygen.core.typeclass.{Show, Showable, StringCodec}
 
 final case class Email private (
     username: String,
-    tag: Option[String],
+    subaddress: Option[Email.Subaddress],
     domain: String,
 ) extends Showable {
 
-  def normalize: Email =
-    Email(
-      username = username.toLowerCase.replace(".", ""),
-      tag = None,
-      domain = domain.toLowerCase,
-    )
+  /** The subaddress tag (the portion after the separator), if present. */
+  def tag: Option[String] = subaddress.map(_.tag)
 
-  override def show: Text = str"${Text.fromString(username)}${tag.fold(Text.empty)(tag => str"+$tag")}@$domain"
+  def normalize: Email = normalize(Email.StripDots.Auto)
+
+  def normalize(stripDots: Email.StripDots): Email = {
+    val loweredUsername = username.toLowerCase
+    val loweredDomain = domain.toLowerCase
+    val shouldStrip = stripDots match
+      case Email.StripDots.Auto => Email.dotInsensitiveDomains.contains(loweredDomain)
+      case Email.StripDots.Yes  => true
+      case Email.StripDots.No   => false
+    Email(
+      username = if shouldStrip then loweredUsername.replace(".", "") else loweredUsername,
+      subaddress = None,
+      domain = loweredDomain,
+    )
+  }
+
+  override def show: Text =
+    str"${Text.fromString(username)}${subaddress.fold(Text.empty)(s => str"${s.separator.toString}${s.tag}")}@$domain"
 
 }
 object Email {
 
-  private val regex = "^([A-Za-z0-9.\\-_%]+)(?:\\+([A-Za-z0-9.\\-_%+]+))?@((?:[A-Za-z0-9\\-]+\\.)+[A-Za-z]{2,})$".r
+  /**
+    * Controls whether dots in the username are stripped during [[Email.normalize]].
+    *
+    * Unlike plus-addressing (which the RFCs leave to the provider but is widely honored), dot-insensitivity is
+    * NOT part of any standard. Gmail chose to ignore dots in the local part, but most providers -- Outlook,
+    * Yahoo, ProtonMail, Fastmail, and essentially every custom domain -- treat dots as significant, so stripping
+    * them there would collapse two genuinely different mailboxes.
+    */
+  enum StripDots {
 
-  def fromString(email: String): Option[Email] = email match
-    case regex(username, tag, domain) => Email(username, Option(tag), domain).some
-    case _                            => None
+    /** Strip dots only for domains known to ignore them (see [[Email.dotInsensitiveDomains]]). */
+    case Auto
+
+    /** Always strip dots from the username. */
+    case Yes
+
+    /** Never strip dots from the username. */
+    case No
+
+  }
+
+  /** Domains known to treat the username as dot-insensitive. Must be lowercase. */
+  private val dotInsensitiveDomains: Set[String] = Set("gmail.com", "googlemail.com")
+
+  /**
+    * Subaddressing (a.k.a. "tag" / "plus") addressing lets `username<sep>tag@domain` route to `username@domain`.
+    * The separator is provider-specific and NOT standardized: most providers (Gmail, Outlook, iCloud, ProtonMail,
+    * Fastmail) use `+`, while the Yahoo family uses `-`. Unknown/custom domains fall back to `+`, the de-facto
+    * default. Only the domain's own separator is treated as a tag boundary, so a `-` in a Gmail username stays part
+    * of the username.
+    */
+  private val DefaultTagSeparator: Char = '+'
+
+  private val tagSeparators: Map[String, Char] =
+    Map(
+      "yahoo.com" -> '-',
+      "ymail.com" -> '-',
+      "rocketmail.com" -> '-',
+    )
+
+  /** The subaddressing separator used by `domain` (case-insensitive), defaulting to `+`. */
+  def tagSeparatorFor(domain: String): Char = tagSeparators.getOrElse(domain.toLowerCase, DefaultTagSeparator)
+
+  /** A parsed subaddress: the provider-specific `separator` paired with the `tag` that followed it. */
+  final case class Subaddress(separator: Char, tag: String)
+
+  private val localPartRegex = "^[A-Za-z0-9.\\-_%+]+$".r
+  private val domainRegex = "^(?:[A-Za-z0-9\\-]+\\.)+[A-Za-z]{2,}$".r
+
+  def fromString(email: String): Option[Email] =
+    email.split("@", -1) match
+      case Array(localPart, domain) if localPartRegex.matches(localPart) && domainRegex.matches(domain) =>
+        val separator = tagSeparatorFor(domain)
+        localPart.indexOf(separator.toInt) match
+          case -1 =>
+            Email(localPart, None, domain).some
+          case idx =>
+            val username = localPart.substring(0, idx)
+            val tag = localPart.substring(idx + 1)
+            // reject an empty username (leading separator) or empty tag (trailing separator)
+            Option.when(username.nonEmpty && tag.nonEmpty)(Email(username, Some(Email.Subaddress(separator, tag)), domain))
+      case _ =>
+        None
 
   def unsafe(email: String): Email = fromString(email).getOrElse { throw Error(s"Invalid email: $email") }
 

--- a/modules/tests/pre-test-unit-tests/src/test/scala/oxygen/core/model/EmailSpec.scala
+++ b/modules/tests/pre-test-unit-tests/src/test/scala/oxygen/core/model/EmailSpec.scala
@@ -1,0 +1,168 @@
+package oxygen.core.model
+
+import oxygen.predef.test.*
+
+object EmailSpec extends OxygenSpecDefault {
+
+  private def parse(raw: String): Option[(String, Option[String], String)] =
+    Email.fromString(raw).map(e => (e.username, e.tag, e.domain))
+
+  private val parsingSpec: TestSpec =
+    suite("parsing")(
+      test("parses a bare address") {
+        assertTrue(parse("john@example.com").contains(("john", None, "example.com")))
+      },
+      test("parses a '+' tag (default separator)") {
+        assertTrue(
+          parse("john+work@gmail.com").contains(("john", Some("work"), "gmail.com")),
+          parse("john+shopping@outlook.com").contains(("john", Some("shopping"), "outlook.com")),
+        )
+      },
+      test("keeps a '+' tag boundary at the first '+' only, tag may contain more '+'") {
+        assertTrue(parse("john+a+b@gmail.com").contains(("john", Some("a+b"), "gmail.com")))
+      },
+      test("uses '-' as the tag separator for the Yahoo family") {
+        assertTrue(
+          parse("john-work@yahoo.com").contains(("john", Some("work"), "yahoo.com")),
+          parse("john-work@ymail.com").contains(("john", Some("work"), "ymail.com")),
+          parse("john-work@rocketmail.com").contains(("john", Some("work"), "rocketmail.com")),
+        )
+      },
+      test("a '-' in a '+'-separator domain stays part of the username") {
+        assertTrue(parse("mary-jane@gmail.com").contains(("mary-jane", None, "gmail.com")))
+      },
+      test("a '+' in a '-'-separator domain stays part of the username") {
+        assertTrue(parse("john+work@yahoo.com").contains(("john+work", None, "yahoo.com")))
+      },
+      test("separator lookup is case-insensitive on the domain") {
+        assertTrue(parse("john-work@YAHOO.COM").contains(("john", Some("work"), "YAHOO.COM")))
+      },
+      test("preserves case at parse time (normalization is a separate step)") {
+        assertTrue(parse("John.Doe@Example.COM").contains(("John.Doe", None, "Example.COM")))
+      },
+      test("allows dots, underscores, hyphens, and percent in the username") {
+        assertTrue(parse("a.b_c-d%e@example.com").contains(("a.b_c-d%e", None, "example.com")))
+      },
+      test("accepts multi-level domains") {
+        assertTrue(parse("john@mail.co.uk").contains(("john", None, "mail.co.uk")))
+      },
+      test("rejects malformed addresses") {
+        assertTrue(
+          Email.fromString("").isEmpty,
+          Email.fromString("john").isEmpty,
+          Email.fromString("john@").isEmpty,
+          Email.fromString("@example.com").isEmpty,
+          Email.fromString("john@example").isEmpty, // no TLD
+          Email.fromString("john@@example.com").isEmpty, // double @
+          Email.fromString("a@b@example.com").isEmpty, // two @
+          Email.fromString("john doe@example.com").isEmpty, // space
+        )
+      },
+      test("rejects a leading separator (empty username)") {
+        assertTrue(
+          Email.fromString("+tag@gmail.com").isEmpty,
+          Email.fromString("-tag@yahoo.com").isEmpty,
+        )
+      },
+      test("rejects a trailing separator (empty tag)") {
+        assertTrue(
+          Email.fromString("john+@gmail.com").isEmpty,
+          Email.fromString("john-@yahoo.com").isEmpty,
+        )
+      },
+      test("captures the separator alongside the tag in the parse result") {
+        assertTrue(
+          Email.fromString("john+work@gmail.com").flatMap(_.subaddress).map(_.separator).contains('+'),
+          Email.fromString("john-work@yahoo.com").flatMap(_.subaddress).map(_.separator).contains('-'),
+          Email.fromString("john+work@gmail.com").flatMap(_.subaddress).map(_.tag).contains("work"),
+          Email.fromString("john@example.com").flatMap(_.subaddress).isEmpty,
+        )
+      },
+      test("round-trips through show for every separator") {
+        assertTrue(
+          Email.fromString("john@example.com").map(_.toString).contains("john@example.com"),
+          Email.fromString("john+work@gmail.com").map(_.toString).contains("john+work@gmail.com"),
+          Email.fromString("john-work@yahoo.com").map(_.toString).contains("john-work@yahoo.com"),
+        )
+      },
+      test("unsafe throws on an invalid address and returns on a valid one") {
+        assertTrue(
+          Email.unsafe("john+work@gmail.com").toString == "john+work@gmail.com",
+          scala.util.Try(Email.unsafe("nope")).isFailure,
+        )
+      },
+    )
+
+  private def normalized(raw: String, stripDots: Email.StripDots): Option[String] =
+    Email.fromString(raw).map(_.normalize(stripDots).toString)
+
+  private def normalizedAuto(raw: String): Option[String] =
+    Email.fromString(raw).map(_.normalize.toString)
+
+  private val normalizationSpec: TestSpec =
+    suite("normalization")(
+      test("lowercases username and domain in all modes") {
+        assertTrue(
+          normalized("John.Doe@Example.COM", Email.StripDots.No).contains("john.doe@example.com"),
+          normalized("John.Doe@Example.COM", Email.StripDots.Yes).contains("johndoe@example.com"),
+          normalized("John.Doe@Example.COM", Email.StripDots.Auto).contains("john.doe@example.com"),
+        )
+      },
+      test("always drops the tag") {
+        assertTrue(
+          normalizedAuto("john+work@gmail.com").contains("john@gmail.com"),
+          normalizedAuto("john-work@yahoo.com").contains("john@yahoo.com"),
+          normalized("john+work@example.com", Email.StripDots.No).contains("john@example.com"),
+        )
+      },
+      suite("StripDots.Auto")(
+        test("strips dots for Gmail-family domains") {
+          assertTrue(
+            normalizedAuto("john.doe@gmail.com").contains("johndoe@gmail.com"),
+            normalizedAuto("john.doe@googlemail.com").contains("johndoe@googlemail.com"),
+            normalizedAuto("John.Doe+promo@GMAIL.com").contains("johndoe@gmail.com"),
+          )
+        },
+        test("keeps dots for providers that treat them as significant") {
+          assertTrue(
+            normalizedAuto("john.doe@outlook.com").contains("john.doe@outlook.com"),
+            normalizedAuto("john.doe@yahoo.com").contains("john.doe@yahoo.com"),
+            normalizedAuto("john.doe@proton.me").contains("john.doe@proton.me"),
+            normalizedAuto("john.doe@example.com").contains("john.doe@example.com"),
+          )
+        },
+      ),
+      suite("StripDots.Yes")(
+        test("strips dots regardless of domain") {
+          assertTrue(
+            normalized("john.doe@gmail.com", Email.StripDots.Yes).contains("johndoe@gmail.com"),
+            normalized("john.doe@outlook.com", Email.StripDots.Yes).contains("johndoe@outlook.com"),
+            normalized("j.o.h.n@example.com", Email.StripDots.Yes).contains("john@example.com"),
+          )
+        },
+      ),
+      suite("StripDots.No")(
+        test("never strips dots, even for Gmail") {
+          assertTrue(
+            normalized("john.doe@gmail.com", Email.StripDots.No).contains("john.doe@gmail.com"),
+            normalized("john.doe@outlook.com", Email.StripDots.No).contains("john.doe@outlook.com"),
+          )
+        },
+      ),
+      test("normalization is idempotent") {
+        assertTrue(
+          List("john.doe+tag@gmail.com", "john-tag@yahoo.com", "A.B@Example.com").forall { raw =>
+            val once = Email.fromString(raw).get.normalize
+            once.normalize == once
+          },
+        )
+      },
+    )
+
+  override def testSpec: TestSpec =
+    suite("EmailSpec")(
+      parsingSpec,
+      normalizationSpec,
+    )
+
+}


### PR DESCRIPTION
## Summary

Reworks `Email` normalization and parsing to respect the fact that dot- and tag-handling rules are **provider-specific, not standardized**.

### `normalize` → `StripDots`
`normalize` previously stripped all dots from the username unconditionally. It now delegates to a sibling `normalize(stripDots: StripDots)`:
- **`Auto`** — strip dots only for domains known to ignore them (Gmail family: `gmail.com`, `googlemail.com`)
- **`Yes`** — always strip
- **`No`** — never strip

Only Gmail ignores dots in the local part; Outlook, Yahoo, ProtonMail, Fastmail, and custom domains treat them as significant, so the old behavior collapsed genuinely different mailboxes.

### Domain-aware subaddress separator
The tag/subaddress separator is also provider-specific: `+` for most providers, `-` for the Yahoo family (`yahoo.com`, `ymail.com`, `rocketmail.com`), defaulting to `+`. Parsing was rewritten to split the tag at the *domain's* separator only — so a `-` in a Gmail username stays part of the username. The separator is captured in a new `Email.Subaddress(separator, tag)` case class; `.tag` is kept as a derived accessor for backward compatibility.

## Tests
New `EmailSpec` covering all parsing (separators, cross-separator cases, malformed/empty-username/empty-tag rejection, round-trip via `show`, `unsafe`) and normalization cases (all three `StripDots` modes, tag dropping, idempotence). 23 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)