### PR TITLE
ci: fix ci-release no-op under sbt 2

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -23,6 +23,20 @@ jobs:
   publish:
     needs: warm-cache
     runs-on: ubuntu-22.04
+    # These must live at the JOB level, not on the `Release` step.
+    # sbt 2 runs a background server: the first `sbt` invocation in the job
+    # (the cache step's `sbt update`, or `sbt +compile`) boots a server that
+    # captures the environment at that moment, and later `sbt` calls just
+    # forward commands to it. ci-release checks `getenv("PGP_SECRET")` inside
+    # that server, so if the secrets are only set on the Release step the
+    # server never sees them and ci-release silently no-ops ("No access to
+    # secret variables, doing nothing"). Setting them job-wide means whichever
+    # sbt call starts the server has the secrets.
+    env:
+      PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+      PGP_SECRET: ${{ secrets.PGP_SECRET }}
+      SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+      SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -36,8 +50,3 @@ jobs:
         run: sbt +compile
       - name: Release
         run: sbt ci-release
-        env:
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}


### PR DESCRIPTION
## Problem

The `0.7.8` release tag ran green, but **nothing was published to Maven Central** (metadata still tops out at `0.7.7`; `oxygen-core_3/0.7.8/` → 404). The `sbt ci-release` step printed:

```
No access to secret variables, doing nothing
[success] elapsed time: 0 s
```

…despite the step's `env:` clearly showing `PGP_SECRET: ***` and the Sonatype secrets set.

## Cause — sbt 2's background server

sbt 2 runs commands through a persistent build **server**. In the `publish` job, the first `sbt` invocation (the cache step's `sbt update`, or `sbt +compile`) boots a server that **captures the environment at that moment**; later `sbt` calls just forward commands to it. `ci-release` checks `getenv("PGP_SECRET")` *inside that server* — and the server was started by a step that had no secrets, so it sees `null` and no-ops.

The `***` on the Release step is real, but it decorates that step's shell — not the long-running server process the client talks to. sbt 1 ran each `sbt` in its own JVM, which is why `0.7.7` published fine two weeks ago with the same `Release.yml`.

## Fix

Hoist the four publish secrets from the `Release` step up to the **`publish` job** `env:`, so whichever `sbt` call first starts the server has them in its environment. A comment documents the reasoning to prevent a future move back to step scope.

Scoping to a single step (or one merged `sbt` invocation) isn't robust here, because the cache composite action can itself run `sbt update` first and start the server without secrets.

## Follow-up

No artifacts were published for `0.7.8`. After this merges, cut a **new tag** (e.g. `0.7.9`, or delete+re-push `0.7.8`) to actually release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)