### PR TITLE
OXY-154: reusable color-theme helper (facade + pickers)

### DIFF
--- a/docs/docs/ui/builders.md
+++ b/docs/docs/ui/builders.md
@@ -186,6 +186,19 @@ Do not reinvent a partial list of sheets unless you know which ones you can drop
 
 ### Theme + color mode
 
+**Preferred:** one combinator wires both color mode (`ColorMode`) and theme pack (`Theme`) — apply
+stored preferences first-paint, then subscribe both to their cross-tab channels:
+
+```scala
+import oxygen.ui.web.service.ColorTheme
+
+override protected def prePageLoad: RIO[Env & Scope, Unit] =
+  ColorTheme.install
+```
+
+`ColorTheme.applyStored` (apply only, no cross-tab subscription) and the underlying
+`ColorMode.*` / `Theme.*` methods remain available for manual wiring:
+
 ```scala
 import oxygen.ui.web.service.{ColorMode, Theme}
 
@@ -195,6 +208,21 @@ override protected def prePageLoad: RIO[Env & Scope, Unit] =
     ColorMode.subscribeCrossTab *>
     Theme.subscribeCrossTab
 ```
+
+**Pickers (UI):** drop-in reusable widgets — no page state to wire:
+
+```scala
+import oxygen.ui.web.component.{ColorModePicker, ThemePicker}
+
+ColorModePicker()                              // Light / Dark / System segmented control
+ColorModePicker(label = Some("Color mode"))
+ThemePicker()                                  // all OxygenThemes packs, as selectable cards
+ThemePicker(OxygenThemes.graphiteFamilyPacks)  // filter to a pack family
+```
+
+Both are self-contained (backed by a shared `GlobalState` seeded from the stored value): they
+reflect the current selection and call `ColorMode.setAndPersist` / `Theme.applyAndPersist` on
+select. They do not re-highlight on cross-tab changes until the page re-renders.
 
 ### Mobile / viewport
 

--- a/docs/docs/ui/index.md
+++ b/docs/docs/ui/index.md
@@ -44,7 +44,7 @@ import oxygen.ui.web.component.*
 import oxygen.ui.web.create.{*, given}
 import oxygen.ui.web.layout.* // HolyGrail, CenteredCard
 import oxygen.ui.web.defaults.* // coreOxygenStyleSheets
-import oxygen.ui.web.service.{ColorMode, Theme}
+import oxygen.ui.web.service.ColorTheme // unified color-mode + theme-pack facade
 ```
 
 Prefer imports over fully-qualified paths at call sites.
@@ -58,10 +58,7 @@ object MyUI extends PageApp[MyEnv] {
     coreOxygenStyleSheets // reset + theme vars + core chrome
 
   override protected def prePageLoad: RIO[MyEnv & Scope, Unit] =
-    ColorMode.applyStoredOrSystem *>
-      Theme.applyStoredOrDefault *>
-      ColorMode.subscribeCrossTab *>
-      Theme.subscribeCrossTab
+    ColorTheme.install // apply stored mode + pack, then keep both in sync across tabs
 
   override val pages: ArraySeq[RoutablePage[MyEnv]] = ArraySeq(
     HomePage,

--- a/example/apps/ui-electron/src/main/scala/oxygen/example/ui/electron/Renderer.scala
+++ b/example/apps/ui-electron/src/main/scala/oxygen/example/ui/electron/Renderer.scala
@@ -4,7 +4,7 @@ import oxygen.example.ui.electron.page as P
 import oxygen.ui.web.*
 import oxygen.ui.web.create.*
 import oxygen.ui.web.defaults.*
-import oxygen.ui.web.service.{ColorMode, Theme}
+import oxygen.ui.web.service.ColorTheme
 import scala.collection.immutable.ArraySeq
 import scala.scalajs.js.annotation.JSExportTopLevel
 import zio.*
@@ -30,8 +30,7 @@ object Renderer extends PageApp[Renderer.Env] {
     coreOxygenStyleSheets
 
   override protected def prePageLoad: RIO[Env & Scope, Unit] =
-    ColorMode.applyStoredOrSystem *>
-      Theme.applyStoredOrDefault
+    ColorTheme.applyStored
 
   override val pages: ArraySeq[RoutablePage[Env]] = ArraySeq(
     P.IndexPage,

--- a/example/apps/ui/src/main/scala/oxygen/example/ui/UIMain.scala
+++ b/example/apps/ui/src/main/scala/oxygen/example/ui/UIMain.scala
@@ -9,7 +9,7 @@ import oxygen.ui.web.*
 import oxygen.ui.web.apispec.ApiSpecPage
 import oxygen.ui.web.create.*
 import oxygen.ui.web.defaults.*
-import oxygen.ui.web.service.{ColorMode, LocalStorage, Theme}
+import oxygen.ui.web.service.{ColorTheme, LocalStorage}
 import scala.collection.immutable.ArraySeq
 import zio.*
 
@@ -33,10 +33,7 @@ object UIMain extends PageApp[UIMain.Env] {
     coreOxygenStyleSheets ++ ArraySeq(P.showcase.pages.MediaQueryStyle.compiled)
 
   override protected def prePageLoad: RIO[Env & Scope, Unit] =
-    ColorMode.applyStoredOrSystem *>
-      Theme.applyStoredOrDefault *>
-      ColorMode.subscribeCrossTab *>
-      Theme.subscribeCrossTab
+    ColorTheme.install
 
   override val pages: ArraySeq[RoutablePage[Env]] = ArraySeq(
     P.index.IndexPage,

--- a/example/apps/ui/src/main/scala/oxygen/example/ui/page/showcase/pages/KitchenSinkPage.scala
+++ b/example/apps/ui/src/main/scala/oxygen/example/ui/page/showcase/pages/KitchenSinkPage.scala
@@ -4,7 +4,6 @@ import oxygen.example.ui.page.showcase.ShowcaseLayout
 import oxygen.ui.web.*
 import oxygen.ui.web.component.*
 import oxygen.ui.web.create.{*, given}
-import oxygen.ui.web.service.ColorMode
 import zio.*
 
 object KitchenSinkPage extends RoutablePage.NoParams[Any] {
@@ -27,8 +26,7 @@ object KitchenSinkPage extends RoutablePage.NoParams[Any] {
           display.flex,
           gap := S.spacing._2,
           flexWrap.wrap,
-          Button("Theme light").small.subtle.content(onClick := ColorMode.setAndPersist(ColorMode.Mode.Light)),
-          Button("Theme dark").small.subtle.content(onClick := ColorMode.setAndPersist(ColorMode.Mode.Dark)),
+          ColorModePicker(), // OXY-154: reusable picker
           Button("Open modal").small.content(onClick := state.update(_.copy(modal = Some(())))),
           Button("Toast").small.informational.content(onClick := PageMessages.add(PageMessage.info("Kitchen sink toast"))),
         ),

--- a/example/apps/ui/src/main/scala/oxygen/example/ui/page/showcase/pages/ShellPage.scala
+++ b/example/apps/ui/src/main/scala/oxygen/example/ui/page/showcase/pages/ShellPage.scala
@@ -4,7 +4,6 @@ import oxygen.example.ui.page.showcase.ShowcaseLayout
 import oxygen.ui.web.*
 import oxygen.ui.web.component.*
 import oxygen.ui.web.create.{*, given}
-import oxygen.ui.web.service.ColorMode
 
 object ShellPage extends ShowcaseLayout.SimplePage {
   override val path: Seq[String] = Seq("showcase", "shell")
@@ -14,10 +13,7 @@ object ShellPage extends ShowcaseLayout.SimplePage {
       ShowcaseLayout.note("TopBar + SideBar + scrollable center. Resize viewport for responsive collapse."),
       p("This page is already inside the showcase HolyGrail shell."),
       div(height := S.spacing._3),
-      Button("System theme").small.subtle.content(onClick := ColorMode.setAndPersist(ColorMode.Mode.System)),
-      span(display.inlineBlock, width := S.spacing._2),
-      Button("Light").small.subtle.content(onClick := ColorMode.setAndPersist(ColorMode.Mode.Light)),
-      span(display.inlineBlock, width := S.spacing._2),
-      Button("Dark").small.subtle.content(onClick := ColorMode.setAndPersist(ColorMode.Mode.Dark)),
+      // OXY-154: reusable ColorModePicker
+      ColorModePicker(),
     )
 }

--- a/example/apps/ui/src/main/scala/oxygen/example/ui/page/showcase/pages/ThemePage.scala
+++ b/example/apps/ui/src/main/scala/oxygen/example/ui/page/showcase/pages/ThemePage.scala
@@ -4,19 +4,21 @@ import oxygen.example.ui.page.showcase.ShowcaseLayout
 import oxygen.ui.web.*
 import oxygen.ui.web.component.*
 import oxygen.ui.web.create.{*, given}
-import oxygen.ui.web.service.{ColorMode, Theme}
-import oxygen.ui.web.style.OxygenThemes
 import zio.*
 
+/**
+  * OXY-154: this page is now a thin consumer of the reusable [[ColorModePicker]] / [[ThemePicker]]
+  * helpers — the hand-rolled mode toggle + pack-card grid were extracted into those widgets.
+  */
 object ThemePage extends RoutablePage.NoParams[Any] {
-  final case class PageState(activeId: String = OxygenThemes.default.id)
+
+  override type PageState = Unit
 
   override val path: Seq[String] = Seq("showcase", "theme")
-  override def title(s: PageState): String = "Theme studio"
-  override def initialLoad(params: Unit): ZIO[Scope, UIError, PageState] =
-    Theme.currentId.map(PageState(_))
-  override def postLoad(state: WidgetState[PageState], initialState: PageState): ZIO[Scope, UIError, Unit] = ZIO.unit
-  override protected def component(state: WidgetState[PageState], renderState: PageState): WidgetS[PageState] =
+  override def title(s: Unit): String = "Theme studio"
+  override def initialLoad(params: Unit): ZIO[Scope, UIError, Unit] = ZIO.unit
+  override def postLoad(state: WidgetState[Unit], initialState: Unit): ZIO[Scope, UIError, Unit] = ZIO.unit
+  override protected def component(state: WidgetState[Unit], renderState: Unit): WidgetS[Unit] =
     ShowcaseLayout
       .page(ThemePage, "Theme studio")(
         ShowcaseLayout.note(
@@ -24,106 +26,21 @@ object ThemePage extends RoutablePage.NoParams[Any] {
             "plus surface personalities (Aurora / Ember / Violet / Ocean). " +
             "Top bar = solid primary + on-primary ink. Light/Dark flips surfaces only.",
         ),
-        // mode
+        // mode — reusable picker
         div(
-          display.flex,
-          alignItems.center,
-          gap := S.spacing._2,
-          flexWrap.wrap,
           marginBottom := S.spacing._5,
-          span(color := S.color.fg.moderate, fontSize := S.fontSize._2, "Color mode"),
-          Button("Light").small.subtle.content(onClick := ColorMode.setAndPersist(ColorMode.Mode.Light)),
-          Button("Dark").small.subtle.content(onClick := ColorMode.setAndPersist(ColorMode.Mode.Dark)),
-          Button("System").small.subtle.content(onClick := ColorMode.setAndPersist(ColorMode.Mode.System)),
+          ColorModePicker(label = Some("Color mode")),
         ),
         h3("Oxygen theme packs", marginBottom := S.spacing._3),
         p(
           color := S.color.fg.moderate,
           fontSize := S.fontSize._2,
           marginBottom := S.spacing._4,
-          s"Active: ${OxygenThemes.byId.get(renderState.activeId).map(_.name).getOrElse(renderState.activeId)}. Tell us which pack becomes the framework default.",
+          "Pick a pack — applied + persisted live. Tell us which pack becomes the framework default.",
         ),
-        div(
-          display.flex,
-          flexDirection.column,
-          gap := S.spacing._3,
-          Widget.foreach(OxygenThemes.all.toList) { pack =>
-            val on = pack.id == renderState.activeId
-            div(
-              display.flex,
-              flexDirection.column,
-              gap := S.spacing._3,
-              padding := S.spacing._4,
-              borderRadius := S.borderRadius._4,
-              border(2.px, "solid", if on then S.color.primary.standard else S.color.bg.layerThree),
-              backgroundColor := S.color.bg.layerOne,
-              // header row
-              div(
-                display.flex,
-                alignItems.center,
-                justifyContent.spaceBetween,
-                gap := S.spacing._3,
-                flexWrap.wrap,
-                div(
-                  div(fontWeight := "700", fontSize := S.fontSize._5, color := S.color.fg.default, pack.name),
-                  div(fontSize := S.fontSize._2, color := S.color.fg.moderate, marginTop := S.spacing._1, pack.blurb),
-                ), {
-                  val label = if on then "Selected" else "Use this theme"
-                  val base = Button(label).small
-                  val btn = if on then base.primary else base.subtle
-                  btn.content(
-                    onClick := (
-                      Theme.applyAndPersist(pack) *>
-                        state.update(_.copy(activeId = pack.id)) *>
-                        PageMessages.schedule(PageMessage.positive(s"Theme: ${pack.name}"), 2.seconds)
-                    ),
-                  )
-                },
-              ),
-              // swatches
-              div(
-                display.flex,
-                gap := S.spacing._2,
-                flexWrap.wrap,
-                themeSwatch("Primary", pack.primarySwatch),
-                themeSwatch("Accent", pack.accentSwatch),
-                themeSwatch("BG", pack.bgSwatch),
-                themeSwatch("Danger", pack.dark.danger),
-                themeSwatch("Success", pack.dark.success),
-              ),
-              // live preview chips using current CSS vars when selected; raw hex chips always
-              div(
-                display.flex,
-                gap := S.spacing._2,
-                flexWrap.wrap,
-                alignItems.center,
-                Button("Primary").small.primary,
-                Button("Accent").small, // default intent
-                Button("Danger").small.negative.subtle,
-                Button("Success").small.positive.subtle,
-                span(color := S.color.fg.subtle, fontSize := S.fontSize._1, "← live tokens (active pack)"),
-              ),
-            )
-          },
-        ),
+        // pack picker — reusable widget renders OxygenThemes.all
+        ThemePicker(),
       )
-
-  private def themeSwatch(label: String, hex: String): Widget =
-    div(
-      display.flex,
-      flexDirection.column,
-      alignItems.center,
-      gap := S.spacing._1,
-      div(
-        width := 40.px,
-        height := 40.px,
-        borderRadius := S.borderRadius._3,
-        backgroundColor := hex,
-        border(1.px, "solid", S.color.bg.layerThree),
-      ),
-      span(fontSize := S.fontSize._1, color := S.color.fg.subtle, label),
-      span(fontSize := S.fontSize._1, color := S.color.fg.minimal, hex),
-    )
 }
 
 /** Full icon catalog + color samples. */

--- a/modules/ui/web/src/main/scala/oxygen/ui/web/component/ColorModePicker.scala
+++ b/modules/ui/web/src/main/scala/oxygen/ui/web/component/ColorModePicker.scala
@@ -61,7 +61,8 @@ object ColorModePicker {
           backgroundColor.dynamic := S.color.bg.layerTwo,
           backgroundColor.dynamic.hover := S.color.bg.layerThree,
           borderColor.dynamic := S.color.bg.layerThree,
-        ),
+        )
+      ,
       mode.pretty,
       onClick := (ColorMode.setAndPersist(mode) *> st.set(mode)),
     )

--- a/modules/ui/web/src/main/scala/oxygen/ui/web/component/ColorModePicker.scala
+++ b/modules/ui/web/src/main/scala/oxygen/ui/web/component/ColorModePicker.scala
@@ -1,0 +1,94 @@
+package oxygen.ui.web.component
+
+import org.scalajs.dom.window
+import oxygen.ui.web.*
+import oxygen.ui.web.create.{*, given}
+import oxygen.ui.web.service.ColorMode
+
+/**
+  * Reusable, drop-in color-mode picker (Light / Dark / System).
+  *
+  * Self-contained: backed by a shared [[GlobalState]] seeded from the stored preference, so it
+  * reflects the current mode and can be dropped into any page without wiring page state. Clicking
+  * an option calls [[ColorMode.setAndPersist]] (persists + rebinds `data-color-mode` + notifies
+  * other tabs) and updates the highlight.
+  *
+  * a11y: `role=radiogroup` container, `role=radio` + `aria-checked` per option.
+  *
+  * {{{
+  * ColorModePicker()                 // just the segmented control
+  * ColorModePicker(label = "Color mode".some)
+  * }}}
+  *
+  * Known limitation (by design, OXY-154): the highlight does not live-update on cross-tab /
+  * programmatic mode changes until the page re-renders. Cross-tab *application* still works via
+  * `ColorTheme.install` / `ColorMode.subscribeCrossTab`.
+  */
+object ColorModePicker {
+
+  private val options: Seq[ColorMode.Mode] =
+    Seq(ColorMode.Mode.Light, ColorMode.Mode.Dark, ColorMode.Mode.System)
+
+  private def readStored: ColorMode.Mode =
+    Option(window.localStorage.getItem(ColorMode.storageKey)).flatMap(ColorMode.parse).getOrElse(ColorMode.Mode.System)
+
+  private object ModeState extends GlobalState[ColorMode.Mode]("ColorModePicker")(readStored)
+
+  private def option(st: WidgetState[ColorMode.Mode], mode: ColorMode.Mode, current: ColorMode.Mode): Widget = {
+    val selected: Boolean = mode == current
+    span(
+      Widget.raw.htmlAttr("role", "radio"),
+      Widget.raw.htmlAttr("aria-checked", if selected then "true" else "false"),
+      Widget.raw.htmlAttr("tabindex", if selected then "0" else "-1"),
+      display.inlineFlex,
+      alignItems.center,
+      cursor.pointer,
+      userSelect.none,
+      padding(S.spacing._1, S.spacing._3),
+      fontSize := S.fontSize._2,
+      fontWeight := S.fontWeight.semiBold,
+      borderStyle.solid,
+      borderWidth := 1.px,
+      if selected then
+        fragment(
+          color.dynamic := S.color.primary.on,
+          backgroundColor.dynamic := S.color.primary.standard,
+          borderColor.dynamic := S.color.primary.standard,
+        )
+      else
+        fragment(
+          color.dynamic := S.color.fg.default,
+          backgroundColor.dynamic := S.color.bg.layerTwo,
+          backgroundColor.dynamic.hover := S.color.bg.layerThree,
+          borderColor.dynamic := S.color.bg.layerThree,
+        ),
+      mode.pretty,
+      onClick := (ColorMode.setAndPersist(mode) *> st.set(mode)),
+    )
+  }
+
+  /** Segmented Light / Dark / System control. Pass `label` to render a leading caption. */
+  def apply(label: Option[String] = None): Widget =
+    Widget.state[ColorMode.Mode].detach(ModeState) { st =>
+      val current: ColorMode.Mode = st.renderTimeValue
+      div(
+        display.inlineFlex,
+        alignItems.center,
+        gap := S.spacing._2,
+        flexWrap.wrap,
+        label match {
+          case Some(text) => span(text, color := S.color.fg.moderate, fontSize := S.fontSize._2)
+          case None       => Widget.empty
+        },
+        div(
+          Widget.raw.htmlAttr("role", "radiogroup"),
+          Widget.raw.htmlAttr("aria-label", "Color mode"),
+          display.inlineFlex,
+          borderRadius := S.borderRadius._3,
+          overflow.hidden,
+          Widget.foreach(options)(option(st, _, current)),
+        ),
+      )
+    }
+
+}

--- a/modules/ui/web/src/main/scala/oxygen/ui/web/component/ThemePicker.scala
+++ b/modules/ui/web/src/main/scala/oxygen/ui/web/component/ThemePicker.scala
@@ -1,0 +1,114 @@
+package oxygen.ui.web.component
+
+import org.scalajs.dom.window
+import oxygen.ui.web.*
+import oxygen.ui.web.create.{*, given}
+import oxygen.ui.web.service.Theme
+import oxygen.ui.web.style.OxygenThemes
+import oxygen.ui.web.style.OxygenThemes.Pack
+
+/**
+  * Reusable, drop-in theme-pack picker. Renders [[OxygenThemes.all]] (or a filtered `packs` list)
+  * as selectable cards (swatch + name + blurb + selected state) and calls [[Theme.applyAndPersist]]
+  * on select.
+  *
+  * Self-contained: backed by a shared [[GlobalState]] seeded from the stored / current pack, so it
+  * reflects the active pack and can be dropped into any page without wiring page state.
+  *
+  * a11y: `role=radiogroup` container, `role=radio` + `aria-checked` per card.
+  *
+  * {{{
+  * ThemePicker()                                      // all packs
+  * ThemePicker(OxygenThemes.graphiteFamilyPacks)      // graphite family only
+  * }}}
+  *
+  * Known limitation (by design, OXY-154): the highlight does not live-update on cross-tab /
+  * programmatic pack changes until the page re-renders. Cross-tab *application* still works via
+  * `ColorTheme.install` / `Theme.subscribeCrossTab`.
+  */
+object ThemePicker {
+
+  private def readStored: String =
+    Option(window.localStorage.getItem(Theme.storageKey))
+      .flatMap(OxygenThemes.parse)
+      .getOrElse(OxygenThemes.default)
+      .id
+
+  private object PackState extends GlobalState[String]("ThemePicker")(readStored)
+
+  private def swatch(label: String, hex: String): Widget =
+    div(
+      display.flex,
+      flexDirection.column,
+      alignItems.center,
+      gap := S.spacing._1,
+      div(
+        width := 40.px,
+        height := 40.px,
+        borderRadius := S.borderRadius._3,
+        backgroundColor := hex,
+        border(1.px, "solid", S.color.bg.layerThree),
+      ),
+      span(fontSize := S.fontSize._1, color := S.color.fg.subtle, label),
+      span(fontSize := S.fontSize._1, color := S.color.fg.minimal, hex),
+    )
+
+  private def card(st: WidgetState[String], pack: Pack, activeId: String): Widget = {
+    val on: Boolean = pack.id == activeId
+    div(
+      Widget.raw.htmlAttr("role", "radio"),
+      Widget.raw.htmlAttr("aria-checked", if on then "true" else "false"),
+      Widget.raw.htmlAttr("aria-label", pack.name),
+      display.flex,
+      flexDirection.column,
+      gap := S.spacing._3,
+      padding := S.spacing._4,
+      borderRadius := S.borderRadius._4,
+      border(2.px, "solid", if on then S.color.primary.standard else S.color.bg.layerThree),
+      backgroundColor := S.color.bg.layerOne,
+      // header row: name/blurb + apply button
+      div(
+        display.flex,
+        alignItems.center,
+        justifyContent.spaceBetween,
+        gap := S.spacing._3,
+        flexWrap.wrap,
+        div(
+          div(fontWeight := S.fontWeight.bold, fontSize := S.fontSize._5, color := S.color.fg.default, pack.name),
+          div(fontSize := S.fontSize._2, color := S.color.fg.moderate, marginTop := S.spacing._1, pack.blurb),
+        ), {
+          val label = if on then "Selected" else "Use this theme"
+          val base = Button(label).small
+          val btn = if on then base.primary else base.subtle
+          btn.content(onClick := (Theme.applyAndPersist(pack) *> st.set(pack.id)))
+        },
+      ),
+      // swatches
+      div(
+        display.flex,
+        gap := S.spacing._2,
+        flexWrap.wrap,
+        swatch("Primary", pack.primarySwatch),
+        swatch("Accent", pack.accentSwatch),
+        swatch("BG", pack.bgSwatch),
+        swatch("Danger", pack.dark.danger),
+        swatch("Success", pack.dark.success),
+      ),
+    )
+  }
+
+  /** Card list for the given packs (defaults to all Oxygen theme packs). */
+  def apply(packs: Seq[Pack] = OxygenThemes.all): Widget =
+    Widget.state[String].detach(PackState) { st =>
+      val activeId: String = st.renderTimeValue
+      div(
+        Widget.raw.htmlAttr("role", "radiogroup"),
+        Widget.raw.htmlAttr("aria-label", "Theme pack"),
+        display.flex,
+        flexDirection.column,
+        gap := S.spacing._3,
+        Widget.foreach(packs.toList)(card(st, _, activeId)),
+      )
+    }
+
+}

--- a/modules/ui/web/src/main/scala/oxygen/ui/web/defaults/StylesPage.scala
+++ b/modules/ui/web/src/main/scala/oxygen/ui/web/defaults/StylesPage.scala
@@ -3,7 +3,6 @@ package oxygen.ui.web.defaults
 import oxygen.ui.web.*
 import oxygen.ui.web.component.*
 import oxygen.ui.web.create.{*, given}
-import oxygen.ui.web.service.ColorMode
 import zio.{Scope, ZIO}
 
 /**
@@ -50,6 +49,7 @@ object StylesPage extends RoutablePage.NoParams[Any] {
       div(height := 25.px),
     )
 
+  // OXY-154: reusable ColorModePicker replaces the hand-rolled Light/Dark/System buttons.
   private lazy val colorModeToggle: Widget =
     div(
       display.flex,
@@ -59,10 +59,7 @@ object StylesPage extends RoutablePage.NoParams[Any] {
       padding := OxygenStyleVars.spacing._4,
       backgroundColor := OxygenStyleVars.color.bg.layerOne,
       borderRadius := OxygenStyleVars.borderRadius._4,
-      span("Color mode:", color := OxygenStyleVars.color.fg.moderate),
-      Button("Light").small.subtle.content(onClick := ColorMode.setAndPersist(ColorMode.Mode.Light)),
-      Button("Dark").small.subtle.content(onClick := ColorMode.setAndPersist(ColorMode.Mode.Dark)),
-      Button("System").small.subtle.content(onClick := ColorMode.setAndPersist(ColorMode.Mode.System)),
+      ColorModePicker(label = Some("Color mode:")),
     )
 
   /** Quick surface / text / status chips for at-a-glance mode checking. */

--- a/modules/ui/web/src/main/scala/oxygen/ui/web/service/ColorTheme.scala
+++ b/modules/ui/web/src/main/scala/oxygen/ui/web/service/ColorTheme.scala
@@ -1,0 +1,50 @@
+package oxygen.ui.web.service
+
+import zio.*
+
+/**
+  * Unified facade over the two independent color-theme services:
+  *   - [[ColorMode]] — light / dark / system (attr `data-color-mode`, key `oxygen.color-mode`)
+  *   - [[Theme]]     — theme pack / `OxygenThemes` (attr `data-oxygen-theme`, key `oxygen.theme-pack`)
+  *
+  * Replaces the copy-pasted `prePageLoad` snippet:
+  * {{{
+  *   ColorMode.applyStoredOrSystem *>
+  *     Theme.applyStoredOrDefault *>
+  *     ColorMode.subscribeCrossTab *>
+  *     Theme.subscribeCrossTab
+  * }}}
+  * with a single combinator:
+  * {{{
+  *   override protected def prePageLoad: RIO[Env & Scope, Unit] = ColorTheme.install
+  * }}}
+  *
+  * The individual [[ColorMode]] / [[Theme]] methods remain public — the manual form still works.
+  */
+object ColorTheme {
+
+  /**
+    * Apply the stored (or system / default) color mode + theme pack to the live document.
+    * Safe to call first-paint from `prePageLoad`. No cross-tab subscription (see [[install]]).
+    */
+  def applyStored: UIO[Unit] =
+    ColorMode.applyStoredOrSystem *>
+      Theme.applyStoredOrDefault
+
+  /**
+    * Subscribe both color mode + theme pack to their cross-tab [[Broadcast]] channels.
+    * Lives for the provided [[Scope]] (app root / `prePageLoad` is the usual home).
+    */
+  def subscribeCrossTab: URIO[Scope, Unit] =
+    ColorMode.subscribeCrossTab *>
+      Theme.subscribeCrossTab
+
+  /**
+    * One-call bootstrap: apply stored preferences, then keep them in sync across tabs.
+    * Preferred over the manual 4-line snippet.
+    */
+  def install: URIO[Scope, Unit] =
+    applyStored *>
+      subscribeCrossTab
+
+}

--- a/report/OXY-154.md
+++ b/report/OXY-154.md
@@ -1,0 +1,60 @@
+# OXY-154 — Reusable helper for color theme
+
+Branch: `OXY-154` (worktree). Epic: OXY-133 (`oxygen-ui-rework`).
+
+## Goal
+Single importable, reusable helper for Oxygen's color theme:
+- Unified bootstrap combinator (`service.ColorTheme.install`) replacing the copy-pasted 4-line `prePageLoad` wiring.
+- Reusable `ColorModePicker` (Light/Dark/System) + `ThemePicker` (pack grid) widgets.
+- No new storage keys / packs / CSS vars. Reuse `S.color.*`. a11y.
+- Refactor `ThemePage`/`StylesPage` (and other dup sites). Update docs.
+
+## Key existing pieces (found)
+- `service/ColorMode.scala` — Mode (System/Light/Dark), `applyStoredOrSystem`, `setAndPersist`, `subscribeCrossTab`. storageKey `oxygen.color-mode`, attr `data-color-mode`.
+- `service/Theme.scala` — `applyStoredOrDefault`, `applyAndPersist`, `currentId`, `subscribeCrossTab`. storageKey `oxygen.theme-pack`, attr `data-oxygen-theme`.
+- `style/OxygenThemes.scala` — `Pack`, `all`, `graphiteFamilyPacks`, `byId`, `default`, `parse`.
+- Widget state model: `GlobalState[S]` + `Widget.state[S].detach(globalState){ st => ... }` gives a page-state-independent, drop-in stateful widget. This is the mechanism used for reusable self-contained widgets (see `PageMessagesBottomCorner` w/ `PageLocalState`).
+- Dup sites: `UIMain.prePageLoad` (+ Renderer) bootstrap; mode toggle in `StylesPage`, `ThemePage`, `ShellPage`, `KitchenSinkPage`; pack picker card grid in `ThemePage`.
+
+## Decisions (resolving open questions)
+1. **Facade location/name** → `oxygen.ui.web.service.ColorTheme` (sibling of `ColorMode`/`Theme`). Matches ticket's `service.ColorTheme.install` suggestion. Provides `applyStored`, `subscribeCrossTab`, `install` (= apply + subscribe). Manual forms kept working (nothing removed).
+2. **Picker state** → self-contained via a shared `GlobalState` seeded from stored value, using `.detach`. Drop-in anywhere (inner state = `Any/Nothing`), no page wiring. Reflects current selection; click updates persistence + highlight. (Rejected pure-stateless because ticket wants "reflecting current mode"; rejected page-owned state because it's not drop-in.)
+3. **Mode picker shape** → segmented buttons (3 options Light/Dark/System), inline `S.color.*` tokens, `role=radiogroup` + `role=radio`/`aria-checked`. Not `HorizontalRadio` (that is `StrictEnum`/form-oriented and heavier).
+4. **Pack picker shape** → vertical card list (swatch row + name + blurb + selected state + apply button), same visuals as current `ThemePage`. One variant shipped.
+5. **Pack filter default** → `OxygenThemes.all` (all 10). `packs` param allows filtering (e.g. `OxygenThemes.graphiteFamilyPacks`).
+6. **Broadcast re-highlight** → NO subscription inside widgets (keep simple). Known limitation: cross-tab / programmatic changes don't live-update a picker's cached highlight until re-render/re-seed. Cross-tab *application* of theme still works (services already subscribe via `ColorTheme.install`). Documented.
+7. **Persistence** → keep `localStorage` (via existing `ColorMode`/`Theme`). OXY-143 config service delegation left for later.
+
+## a11y
+- `role=radiogroup` + `aria-label` on container; each option `role=radio` + `aria-checked`. (Ticket hinted `aria-pressed`; radiogroup+aria-checked is the semantically correct pairing for single-select.)
+
+## Work log / files changed
+New:
+- `modules/ui/web/.../service/ColorTheme.scala` — facade: `applyStored`, `subscribeCrossTab`, `install`.
+- `modules/ui/web/.../component/ColorModePicker.scala` — segmented Light/Dark/System, self-contained via `GlobalState`.
+- `modules/ui/web/.../component/ThemePicker.scala` — pack-card grid, `packs` filter, self-contained via `GlobalState`.
+
+Refactored:
+- `example/.../UIMain.scala` — `prePageLoad = ColorTheme.install`.
+- `example/.../electron/Renderer.scala` — `prePageLoad = ColorTheme.applyStored` (no cross-tab sub, matching prior behaviour).
+- `modules/ui/web/.../defaults/StylesPage.scala` — mode buttons → `ColorModePicker`.
+- `example/.../pages/ThemePage.scala` — mode buttons → `ColorModePicker`; pack grid → `ThemePicker`; state simplified to `Unit`.
+- `example/.../pages/ShellPage.scala` — mode buttons → `ColorModePicker`.
+- `example/.../pages/KitchenSinkPage.scala` — light/dark buttons → `ColorModePicker`.
+- `docs/docs/ui/index.md`, `docs/docs/ui/builders.md` — show `ColorTheme.install` + pickers as preferred (manual form kept as fallback).
+
+## Verification
+- `-Werror -Wunused:all` is on. Compiled clean: `oxygen-ui-web`, `example-ui-web`, `oxygen-ui-electron`, `example-ui-electron`.
+- Did NOT run Scala.js test suites (node-based; no logic under existing tests changed). No new tests added — widgets are visual/DOM.
+- Note: sbt-git's jgit `hasUncommittedChanges` throws inside a git *worktree* (unrelated to this change). Verified compile by temporarily setting `git.gitUncommittedChanges := false` in build.sbt, then reverting. A CI checkout (non-worktree) is unaffected.
+
+## Assumptions / notable choices
+- Behaviour parity kept: nothing removed from `ColorMode` / `Theme`; manual wiring still compiles/works.
+- ThemePage lost its per-pack "live token chips" row + toast-on-apply + dynamic "Active: X" text label when extracting into `ThemePicker` (kept the swatch/name/blurb/selected/apply-button essentials the ticket specified). Reasonable trade for a reusable widget; can be added back as `ThemePicker` options if desired.
+- Pickers cache selection in a shared `GlobalState` seeded from `localStorage`; they do NOT subscribe to `Broadcast`, so cross-tab/programmatic changes don't re-highlight until re-render (documented; theme *application* across tabs still works via `ColorTheme.install`).
+- a11y: `role=radiogroup` + `role=radio`/`aria-checked` (semantically correct single-select; ticket's `aria-pressed` hint interpreted as "expose selected state").
+- Electron renderer intentionally uses `applyStored` (not `install`) to preserve its original no-cross-tab behaviour.
+
+## CONFIDENCE: 7.5/10
+- High confidence it compiles and satisfies the ticket's required changes (facade + both pickers + page/doc refactors, no new keys/packs/vars, a11y).
+- Lower confidence on exact visual/UX expectations: pickers not run in a live browser (couldn't launch Scala.js app here); dropped a few ThemePage extras; GlobalState-seed reflection is correct for normal use but has the documented cross-tab-highlight limitation. `HorizontalRadio` could arguably have been reused for the mode picker instead of a bespoke segmented control.


### PR DESCRIPTION
## What

Implements OXY-154 (epic OXY-133 `oxygen-ui-rework`): a single reusable surface for Oxygen's color theme, covering both bootstrap wiring and the duplicated picker UI.

**New**
- `service.ColorTheme` — unified facade over `ColorMode` + `Theme`. `install` (apply stored mode+pack, then subscribe both cross-tab) replaces the copy-pasted 4-line `prePageLoad` snippet; also `applyStored` / `subscribeCrossTab`. Manual `ColorMode`/`Theme` forms still work (nothing removed).
- `component.ColorModePicker` — drop-in Light/Dark/System segmented control; self-contained via a shared `GlobalState`; calls `ColorMode.setAndPersist`.
- `component.ThemePicker` — drop-in `OxygenThemes` pack-card grid (swatch + name + blurb + selected state), `packs` filter; calls `Theme.applyAndPersist`.

**Constraints honored**: no new storage keys / pack defs / CSS vars; reuses `S.color.*`; a11y via `role=radiogroup` + `role=radio`/`aria-checked`.

**Refactors**: `UIMain` -> `ColorTheme.install`; electron `Renderer` -> `ColorTheme.applyStored`; `StylesPage` / `ThemePage` / `ShellPage` / `KitchenSinkPage` -> the pickers; `docs/ui/index.md` + `builders.md` show the helper as preferred.

## Verification
Compiles clean under `-Werror -Wunused:all`: `oxygen-ui-web`, `example-ui-web`, `oxygen-ui-electron`, `example-ui-electron`. Not run in a live browser; no Scala.js test suites executed (no tested logic changed).

## Notes
- Pickers cache selection in `GlobalState` seeded from `localStorage`; they don't subscribe to `Broadcast`, so cross-tab/programmatic changes don't re-highlight until re-render (theme *application* across tabs still works via `ColorTheme.install`).
- `ThemePage` dropped a few extras (live-token chips, apply toast, dynamic "Active:" label) when extracting into `ThemePicker`.

Decisions, resolved open questions, and an honest confidence score (**7.5/10**) are in `report/OXY-154.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)