### PR TITLE
OXY-158: composable media-query support in the stylesheet DSL

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,14 @@ ThisBuild / libraryDependencySchemes += "org.scala-native" % "test-interface_nat
 enablePlugins(GitVersioning)
 // JGit can't read linked git worktrees (bare-repo error); shell out to the git CLI instead
 ThisBuild / com.github.sbt.git.SbtGit.GitKeys.useConsoleForROGit := true
+// We override versioning by hand below (custom `version`, `useGitDescribe := false`), so sbt-git's
+// describe keys go unused. sbt 2.x's lintUnusedKeysOnLoad otherwise spams ~84 warnings (one per
+// module) on every load — exclude exactly those keys, keeping the lint active for everything else.
+Global / excludeLintKeys ++= Set(
+  com.github.sbt.git.SbtGit.GitKeys.useGitDescribe,
+  com.github.sbt.git.SbtGit.GitKeys.gitDescribedVersion,
+  com.github.sbt.git.SbtGit.GitKeys.versionProperty,
+)
 git.gitTagToVersionNumber := { tag =>
   if (tag.matches("^\\d+\\..*$")) Some(tag)
   else None

--- a/docs/docs/executable/index.md
+++ b/docs/docs/executable/index.md
@@ -273,7 +273,7 @@ showcase (flat/nested commands, every annotation, env layers) lives at
 `example/apps/example-app/.../ShowcaseApp.scala`.
 
 ```bash
-APP_CONFIG=example/apps/web-server/src/main/resources/local.json sbt "example-web-server/run"
+APP_CONFIG=example/apps/web-server/config/local.yaml sbt "example-web-server/run"
 ```
 
 ## Further reading

--- a/docs/docs/executable/migration-from-v1.md
+++ b/docs/docs/executable/migration-from-v1.md
@@ -226,7 +226,7 @@ export APP_CONFIG=/etc/myapp/config.json
 Or for local dev from the repo:
 
 ```bash
-APP_CONFIG=example/apps/web-server/src/main/resources/local.json sbt "example-web-server/run"
+APP_CONFIG=example/apps/web-server/config/local.yaml sbt "example-web-server/run"
 ```
 
 Until bootstrap `-f`/`-j`/merge returns, this env-or-file pattern is the supported migration path.

--- a/docs/docs/sql/database.md
+++ b/docs/docs/sql/database.md
@@ -18,7 +18,7 @@ final case class DbConfig(
 )
 ```
 
-As JSON (from the example app's `local.json`):
+As JSON (the example app sets the same fields as YAML in `example/apps/web-server/config/local.yaml`):
 
 ```json
 {

--- a/example/apps/ui/src/main/scala/oxygen/example/ui/UIMain.scala
+++ b/example/apps/ui/src/main/scala/oxygen/example/ui/UIMain.scala
@@ -30,7 +30,7 @@ object UIMain extends PageApp[UIMain.Env] {
    */
 
   override val styleSheets: ArraySeq[StyleSheet] =
-    coreOxygenStyleSheets
+    coreOxygenStyleSheets ++ ArraySeq(P.showcase.pages.MediaQueryStyle.compiled)
 
   override protected def prePageLoad: RIO[Env & Scope, Unit] =
     ColorMode.applyStoredOrSystem *>
@@ -75,6 +75,7 @@ object UIMain extends PageApp[UIMain.Env] {
     P.showcase.pages.MessagesPage,
     P.showcase.pages.AnchorsPage,
     P.showcase.pages.GridPage,
+    P.showcase.pages.MediaQueryPage,
     P.showcase.pages.KitchenSinkPage,
   )
 

--- a/example/apps/ui/src/main/scala/oxygen/example/ui/page/showcase/ShowcaseLayout.scala
+++ b/example/apps/ui/src/main/scala/oxygen/example/ui/page/showcase/ShowcaseLayout.scala
@@ -66,6 +66,7 @@ object ShowcaseLayout {
       navItem("Messages", MessagesPage, currentPath),
       navItem("Anchors", AnchorsPage, currentPath),
       navItem("Grid", GridPage, currentPath),
+      navItem("Media queries", MediaQueryPage, currentPath),
       navItem("Kitchen sink", KitchenSinkPage, currentPath),
     )
 

--- a/example/apps/ui/src/main/scala/oxygen/example/ui/page/showcase/pages/MediaQueryPage.scala
+++ b/example/apps/ui/src/main/scala/oxygen/example/ui/page/showcase/pages/MediaQueryPage.scala
@@ -1,0 +1,122 @@
+package oxygen.example.ui.page.showcase.pages
+
+import oxygen.example.ui.page.showcase.ShowcaseLayout
+import oxygen.ui.web.*
+import oxygen.ui.web.create.{*, given}
+
+/**
+  * Responsive styles built entirely with the composable media-query DSL (OXY-158).
+  *
+  * Every responsive rule on this page is authored with the ordinary selector DSL wrapped in a
+  * `media(MediaQuery.*) { ... }` block — no hand-written `@media` strings. The stylesheet compiles
+  * to correct `@media (...) { selector { ... } }` CSS.
+  */
+object MediaQueryStyle extends StyleSheetBuilder {
+
+  // Panel of cards: stacked on phones, row from `md` up.
+  object Panel extends Class("mq-panel") { p =>
+
+    Panel(
+      display.flex,
+      flexDirection.column,
+      gap := S.spacing._3,
+      padding := S.spacing._4,
+      borderRadius := S.borderRadius._3,
+      border(1.px, "solid", S.color.bg.layerThree),
+      backgroundColor := S.color.bg.layerTwo,
+    )
+
+    // `md` and up → lay the cards out in a row. Same DSL as above; the wrapper is emitted for us.
+    media(MediaQuery.mdUp) {
+      Panel(flexDirection.row)
+    }
+
+    // Compose conditions: nudge the accent when the user prefers a dark color scheme.
+    media(MediaQuery.prefersDark) {
+      Panel(borderColor := S.color.primary.strong)
+    }
+
+    object Card extends p.Class("card") {
+      Card(
+        flex := "1 1 0",
+        padding := S.spacing._4,
+        borderRadius := S.borderRadius._2,
+        backgroundColor := S.color.primary.subtle,
+        color := S.color.fg.default,
+        textAlign.center,
+        fontWeight := "600",
+      )
+    }
+
+  }
+
+  // Responsive visibility helpers — one shows only below `md`, the other only from `md` up.
+  object OnlyMobile extends Class("mq-only-mobile") {
+    selector(display.none)
+    media(MediaQuery.belowMd) { selector(display.block) }
+  }
+
+  object OnlyDesktop extends Class("mq-only-desktop") {
+    selector(display.none)
+    media(MediaQuery.mdUp) { selector(display.block) }
+  }
+
+  override val compiled: StyleSheet = StyleSheet.derived[MediaQueryStyle.type]
+
+}
+
+object MediaQueryPage extends ShowcaseLayout.SimplePage {
+  override val path: Seq[String] = Seq("showcase", "responsive", "media-query")
+  override def pageTitle: String = "Media queries (DSL)"
+
+  private def card(label: String): Widget =
+    div(MediaQueryStyle.Panel.Card, label)
+
+  override def body: Widget =
+    fragment(
+      ShowcaseLayout.note(
+        "Responsive styles authored with the composable media-query DSL (OXY-158): " +
+          "`media(MediaQuery.mdUp) { Panel(flexDirection.row) }` — no raw @media strings. " +
+          "Resize the window across the md breakpoint (768px) to watch each demo react.",
+      ),
+      h3("1 · Reflow (stack on phone, row from md up)", marginBottom := S.spacing._3),
+      p(
+        color := S.color.fg.moderate,
+        fontSize := S.fontSize._2,
+        marginBottom := S.spacing._3,
+        "The panel is `flex-direction: column` by default and switches to `row` inside `@media (min-width: 768px)`.",
+      ),
+      div(
+        MediaQueryStyle.Panel,
+        card("Card A"),
+        card("Card B"),
+        card("Card C"),
+      ),
+      div(height := S.spacing._6),
+      h3("2 · Responsive visibility", marginBottom := S.spacing._3),
+      p(
+        color := S.color.fg.moderate,
+        fontSize := S.fontSize._2,
+        marginBottom := S.spacing._3,
+        "Two classes whose `display` flips at the breakpoint — exactly one is visible at a time.",
+      ),
+      div(
+        MediaQueryStyle.OnlyMobile,
+        padding := S.spacing._3,
+        borderRadius := S.borderRadius._2,
+        backgroundColor := S.color.status.alert.subtle,
+        color := S.color.fg.default,
+        fontWeight := "600",
+        "Narrow viewport — you are below md (< 768px).",
+      ),
+      div(
+        MediaQueryStyle.OnlyDesktop,
+        padding := S.spacing._3,
+        borderRadius := S.borderRadius._2,
+        backgroundColor := S.color.status.positive.subtle,
+        color := S.color.fg.default,
+        fontWeight := "600",
+        "Wide viewport — you are at md or above (>= 768px).",
+      ),
+    )
+}

--- a/modules/ui/web/src/main/scala/oxygen/ui/web/create/MediaCSS.scala
+++ b/modules/ui/web/src/main/scala/oxygen/ui/web/create/MediaCSS.scala
@@ -4,7 +4,12 @@ import oxygen.ui.web.style.Breakpoints
 
 /**
   * W5-T02: sanctioned helpers to emit `@media` CSS without a full media-query DSL.
-  * Prefer these over hand-written strings at call sites.
+  *
+  * ''Prefer the composable [[MediaQuery]] + [[media]] DSL (OXY-158) for new stylesheet code'' —
+  * it lets responsive rules be written with the same selector DSL as everything else and emits the
+  * `@media` wrapper for you. These raw-string helpers remain for legacy raw sheets
+  * (e.g. [[oxygen.ui.web.component.ColumnsStyle]], [[oxygen.ui.web.layout.HolyGrail]]) that are not
+  * built through a [[StyleSheetBuilder]].
   */
 object MediaCSS {
 

--- a/modules/ui/web/src/main/scala/oxygen/ui/web/create/MediaQuery.scala
+++ b/modules/ui/web/src/main/scala/oxygen/ui/web/create/MediaQuery.scala
@@ -1,0 +1,141 @@
+package oxygen.ui.web.create
+
+import oxygen.ui.web.style.Breakpoints
+
+/**
+  * Composable media-query condition for the stylesheet DSL (OXY-158).
+  *
+  * Instead of dropping down to raw `@media (...)` CSS strings, build responsive
+  * conditions with the same ergonomic, composable DSL as the rest of the sheet and
+  * apply them with the [[oxygen.ui.web.create.media]] block:
+  *
+  * {{{
+  * media(MediaQuery.belowMd) {
+  *   MyClass(display.none)
+  * }
+  *
+  * media(MediaQuery.mdUp && MediaQuery.landscape) {
+  *   MyClass(flexDirection.row)
+  * }
+  * }}}
+  *
+  * `query` renders the raw condition text that follows `@media ` (e.g. `(min-width: 768px)`).
+  */
+sealed trait MediaQuery {
+
+  /** The raw condition text placed after `@media ` (e.g. `(min-width: 768px) and (orientation: landscape)`). */
+  def query: String
+
+  /** Logical AND — both conditions must hold (`a and b`). */
+  final def &&(that: MediaQuery): MediaQuery = MediaQuery.And(this, that)
+
+  /** Logical AND — both conditions must hold (`a and b`). */
+  final def and(that: MediaQuery): MediaQuery = MediaQuery.And(this, that)
+
+  /** Logical OR — either condition may hold (comma list `a, b`). */
+  final def ||(that: MediaQuery): MediaQuery = MediaQuery.Or(this, that)
+
+  /** Logical OR — either condition may hold (comma list `a, b`). */
+  final def or(that: MediaQuery): MediaQuery = MediaQuery.Or(this, that)
+
+}
+object MediaQuery {
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////////
+  //      Tree
+  //////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  /** A single, already-rendered condition, e.g. `(min-width: 768px)` or a media type like `screen`. */
+  final case class Feature(rendered: String) extends MediaQuery {
+    override def query: String = rendered
+  }
+
+  final case class And(a: MediaQuery, b: MediaQuery) extends MediaQuery {
+    override def query: String = s"${a.query} and ${b.query}"
+  }
+
+  final case class Or(a: MediaQuery, b: MediaQuery) extends MediaQuery {
+    override def query: String = s"${a.query}, ${b.query}"
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////////
+  //      Constructors
+  //////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  /** Escape hatch for any raw condition text (placed after `@media `). */
+  def raw(rendered: String): MediaQuery = Feature(rendered)
+
+  // ---  Width / height  ---
+
+  def minWidth(px: Int): MediaQuery = Feature(s"(min-width: ${px}px)")
+  def maxWidth(px: Int): MediaQuery = Feature(s"(max-width: ${px}px)")
+  def minHeight(px: Int): MediaQuery = Feature(s"(min-height: ${px}px)")
+  def maxHeight(px: Int): MediaQuery = Feature(s"(max-height: ${px}px)")
+
+  // ---  Breakpoints (mobile-first, from Breakpoints scale)  ---
+
+  /** `>= sm` (≥480px). */
+  def smUp: MediaQuery = minWidth(Breakpoints.sm)
+
+  /** `>= md` (≥768px). */
+  def mdUp: MediaQuery = minWidth(Breakpoints.md)
+
+  /** `>= lg` (≥1024px). */
+  def lgUp: MediaQuery = minWidth(Breakpoints.lg)
+
+  /** `>= xl` (≥1280px). */
+  def xlUp: MediaQuery = minWidth(Breakpoints.xl)
+
+  /** `< sm` — below the `sm` breakpoint. */
+  def belowSm: MediaQuery = maxWidth(Breakpoints.sm - 1)
+
+  /** `< md` — the typical "mobile shell" band. */
+  def belowMd: MediaQuery = maxWidth(Breakpoints.md - 1)
+
+  /** `< lg`. */
+  def belowLg: MediaQuery = maxWidth(Breakpoints.lg - 1)
+
+  /** `< xl`. */
+  def belowXl: MediaQuery = maxWidth(Breakpoints.xl - 1)
+
+  /** Inclusive-min / exclusive-max band `[minPx, maxPxExclusive)`. */
+  def between(minPx: Int, maxPxExclusive: Int): MediaQuery =
+    minWidth(minPx) && maxWidth(maxPxExclusive - 1)
+
+  // ---  Color scheme  ---
+
+  /** `(prefers-color-scheme: dark)`. */
+  val prefersDark: MediaQuery = Feature("(prefers-color-scheme: dark)")
+
+  /** `(prefers-color-scheme: light)`. */
+  val prefersLight: MediaQuery = Feature("(prefers-color-scheme: light)")
+
+  // ---  Orientation  ---
+
+  val portrait: MediaQuery = Feature("(orientation: portrait)")
+  val landscape: MediaQuery = Feature("(orientation: landscape)")
+
+  // ---  Motion / interaction  ---
+
+  /** `(prefers-reduced-motion: reduce)`. */
+  val reducedMotion: MediaQuery = Feature("(prefers-reduced-motion: reduce)")
+
+  /** `(prefers-reduced-motion: no-preference)`. */
+  val allowsMotion: MediaQuery = Feature("(prefers-reduced-motion: no-preference)")
+
+  /** `(hover: hover)` — pointing device that can hover (mouse, not touch). */
+  val canHover: MediaQuery = Feature("(hover: hover)")
+
+  /** `(pointer: coarse)` — imprecise pointer (touch). */
+  val coarsePointer: MediaQuery = Feature("(pointer: coarse)")
+
+  /** `(pointer: fine)` — precise pointer (mouse/stylus). */
+  val finePointer: MediaQuery = Feature("(pointer: fine)")
+
+  // ---  Media types  ---
+
+  val screen: MediaQuery = Feature("screen")
+  val print: MediaQuery = Feature("print")
+  val all: MediaQuery = Feature("all")
+
+}

--- a/modules/ui/web/src/main/scala/oxygen/ui/web/create/OxygenStyleSheet.scala
+++ b/modules/ui/web/src/main/scala/oxygen/ui/web/create/OxygenStyleSheet.scala
@@ -31,6 +31,14 @@ object OxygenStyleSheet extends StyleSheetBuilder {
     marginTop := "0",
   )
 
+  // OXY-158: composable media queries — trim the h1 on narrow (phone) viewports.
+  // Written with the ordinary selector DSL; the `@media (max-width: …)` wrapper is emitted for us.
+  media(MediaQuery.belowMd) {
+    T.h1.apply(
+      fontSize := "1.5rem",
+    )
+  }
+
   T.apply("*")
     .apply(
       boxSizing.borderBox,

--- a/modules/ui/web/src/main/scala/oxygen/ui/web/create/StyleSheet.scala
+++ b/modules/ui/web/src/main/scala/oxygen/ui/web/create/StyleSheet.scala
@@ -26,36 +26,61 @@ object StyleSheet {
     StyleSheet(header, () => body)
 
   def compile(header: String, elems: => Seq[Growable[StyleSheetElement.AppliedStyleSheet]]): StyleSheet = {
+    // Consecutive (media-query, selector) run of css key/value pairs → one rule block.
+    final case class Group(media: Option[MediaQuery], selector: String, pairs: Growable[(String, String)])
+
     @tailrec
     def loop(
-        current: Option[(String, Growable[(String, String)])],
+        current: Option[Group],
         queue: List[StyleSheetElement.Leaf],
-        acc: Growable[(String, Growable[(String, String)])],
-    ): Growable[(String, Growable[(String, String)])] =
+        acc: Growable[Group],
+    ): Growable[Group] =
       queue match {
         case head :: tail =>
           current match {
-            case Some((currentKey, currentElems)) if head.selectorString == currentKey =>
-              loop((currentKey, currentElems :+ (head.key, head.value)).some, tail, acc)
-            case Some(current) =>
-              loop((head.selectorString, Growable.single((head.key, head.value))).some, tail, acc :+ current)
+            case Some(g) if g.media == head.media && g.selector == head.selectorString =>
+              loop(g.copy(pairs = g.pairs :+ (head.key, head.value)).some, tail, acc)
+            case Some(g) =>
+              loop(Group(head.media, head.selectorString, Growable.single((head.key, head.value))).some, tail, acc :+ g)
             case None =>
-              loop((head.selectorString, Growable.single((head.key, head.value))).some, tail, acc)
+              loop(Group(head.media, head.selectorString, Growable.single((head.key, head.value))).some, tail, acc)
           }
         case Nil =>
           acc ++ Growable.option(current)
       }
 
-    StyleSheet.makeLazy(header)(
-      loop(
-        None,
-        Growable.many(elems).flatten.flatMap(_.leafs).toArraySeq.sortBy(_.loc.line).toList,
-        Growable.empty,
-      ).map { case (selector, pairs) =>
-        s"$selector {${pairs.map { case (k, v) => s"\n  $k: $v;" }.to[Seq].mkString}\n}"
-      }.to[Seq]
-        .mkString("\n\n"),
-    )
+    def renderRule(selector: String, pairs: Growable[(String, String)]): String =
+      s"$selector {${pairs.map { case (k, v) => s"\n  $k: $v;" }.to[Seq].mkString}\n}"
+
+    def indent(body: String): String =
+      body.linesIterator.map { line => if line.isEmpty then line else s"  $line" }.mkString("\n")
+
+    StyleSheet.makeLazy(header) {
+      val groups: List[Group] =
+        loop(
+          None,
+          Growable.many(elems).flatten.flatMap(_.leafs).toArraySeq.sortBy(_.loc.line).toList,
+          Growable.empty,
+        ).toArraySeq.toList
+
+      // Merge consecutive groups sharing the same media query into a single segment, so that all
+      // rules under one `@media` block end up wrapped together (bare rules stay unwrapped).
+      val segments: List[(Option[MediaQuery], List[Group])] =
+        groups.foldRight(List.empty[(Option[MediaQuery], List[Group])]) { (g, acc) =>
+          acc match {
+            case (m, gs) :: rest if m == g.media => (m, g :: gs) :: rest
+            case _                               => (g.media, g :: Nil) :: acc
+          }
+        }
+
+      segments.map {
+        case (None, gs) =>
+          gs.map { g => renderRule(g.selector, g.pairs) }.mkString("\n\n")
+        case (Some(mq), gs) =>
+          val inner = gs.map { g => renderRule(g.selector, g.pairs) }.mkString("\n\n")
+          s"@media ${mq.query} {\n${indent(inner)}\n}"
+      }.mkString("\n\n")
+    }
   }
 
   def variables(header: String, scope: String = ":root")(vars: (CSSVar, String)*): StyleSheet =

--- a/modules/ui/web/src/main/scala/oxygen/ui/web/create/media.scala
+++ b/modules/ui/web/src/main/scala/oxygen/ui/web/create/media.scala
@@ -1,0 +1,35 @@
+package oxygen.ui.web.create
+
+import oxygen.ui.web.internal.StyleSheetElement
+
+/**
+  * Apply a [[MediaQuery]] to every rule emitted inside `body` (OXY-158).
+  *
+  * This makes responsive styles first-class in the stylesheet DSL: instead of dropping down to raw
+  * `@media (...)` CSS strings, wrap ordinary selector rules in a `media(...) { ... }` block and they
+  * are emitted inside a correct `@media` block at compile time.
+  *
+  * {{{
+  * object MySheet extends StyleSheetBuilder {
+  *   object Card extends Class("card") {
+  *     selector(display.flex, flexDirection.row)
+  *
+  *     // Stack on narrow viewports — same DSL, no raw strings.
+  *     media(MediaQuery.belowMd) {
+  *       selector(flexDirection.column)
+  *     }
+  *   }
+  *
+  *   override val compiled: StyleSheet = StyleSheet.derived[MySheet.type]
+  * }
+  * }}}
+  *
+  * Blocks nest and compose: a `media` inside another `media` ANDs the two conditions together.
+  * The implicit [[StyleSheetBuilder.MutableAdder]] comes from the enclosing builder / class body,
+  * exactly like a bare `selector(...)` call.
+  */
+def media(query: MediaQuery)(body: StyleSheetBuilder.MutableAdder ?=> Unit)(using outer: StyleSheetBuilder.MutableAdder): Unit = {
+  val tagging: StyleSheetBuilder.MutableAdder =
+    (ass: StyleSheetElement.AppliedStyleSheet) => outer.add(ass.withMedia(query))
+  body(using tagging)
+}

--- a/modules/ui/web/src/main/scala/oxygen/ui/web/internal/StyleSheetElement.scala
+++ b/modules/ui/web/src/main/scala/oxygen/ui/web/internal/StyleSheetElement.scala
@@ -1,38 +1,58 @@
 package oxygen.ui.web.internal
 
 import oxygen.predef.core.*
+import oxygen.ui.web.create.MediaQuery
 import zio.internal.stacktracer.SourceLocation
 
 sealed trait StyleSheetElement {
 
-  def leafs(parent: StyleSheetSelector): Growable[StyleSheetElement.Leaf]
+  def leafs(parent: StyleSheetSelector, media: Option[MediaQuery]): Growable[StyleSheetElement.Leaf]
 
 }
 object StyleSheetElement {
+
+  /** Combine an outer media query with an inner one (nested `media` blocks AND together). */
+  private[web] def combineMedia(outer: Option[MediaQuery], inner: Option[MediaQuery]): Option[MediaQuery] =
+    (outer, inner) match {
+      case (Some(o), Some(i)) => Some(o && i)
+      case (Some(o), None)    => Some(o)
+      case (None, i)          => i
+    }
 
   final case class Leaf(
       selector: StyleSheetSelector,
       loc: SourceLocation,
       key: String,
       value: String,
+      media: Option[MediaQuery],
   ) {
     lazy val selectorString: String = selector.show
+    def mediaQueryString: Option[String] = media.map(_.query)
   }
 
-  final case class AppliedStyleSheet(selector: StyleSheetSelector, loc: SourceLocation, elems: Seq[StyleSheetElement]) extends StyleSheetElement {
+  final case class AppliedStyleSheet(
+      selector: StyleSheetSelector,
+      loc: SourceLocation,
+      elems: Seq[StyleSheetElement],
+      media: Option[MediaQuery] = None,
+  ) extends StyleSheetElement {
+
+    /** Wrap this applied sheet (and everything it contains) in an additional (outer) media query. */
+    def withMedia(mq: MediaQuery): AppliedStyleSheet =
+      copy(media = Some(media.fold(mq)(mq && _)))
 
     def leafs: Growable[Leaf] =
-      Growable.many(elems).flatMap(_.leafs(selector))
+      Growable.many(elems).flatMap(_.leafs(selector, media))
 
-    override def leafs(parent: StyleSheetSelector): Growable[Leaf] =
-      AppliedStyleSheet(parent >> selector, loc, elems).leafs
+    override def leafs(parent: StyleSheetSelector, parentMedia: Option[MediaQuery]): Growable[Leaf] =
+      AppliedStyleSheet(parent >> selector, loc, elems, combineMedia(parentMedia, media)).leafs
 
   }
 
   final case class CSS(key: String, value: Lazy[String], loc: SourceLocation) extends StyleSheetElement {
 
-    override def leafs(parent: StyleSheetSelector): Growable[Leaf] =
-      Growable.single(Leaf(parent, loc, key, value.value))
+    override def leafs(parent: StyleSheetSelector, media: Option[MediaQuery]): Growable[Leaf] =
+      Growable.single(Leaf(parent, loc, key, value.value, media))
 
   }
 

--- a/modules/ui/web/src/test/scala/oxygen/ui/web/style/OxygenColorSystemSpec.scala
+++ b/modules/ui/web/src/test/scala/oxygen/ui/web/style/OxygenColorSystemSpec.scala
@@ -4,12 +4,36 @@ import java.time.YearMonth
 import oxygen.predef.test.*
 import oxygen.ui.web.{LockState, Memo, PageURL}
 import oxygen.ui.web.component.{ColorPicker, DatePicker, DateTimePicker, Icon, InfiniteScroll, LazySection, Pagination, Progress, SideBar, SortableList, Tabs, TimePicker, TopBar}
-import oxygen.ui.web.create.{AnchorId, CSSColor, MediaCSS, Motion}
+import oxygen.ui.web.create.{AnchorId, CSSColor, MediaCSS, MediaQuery, Motion}
 import oxygen.ui.web.service.{IndexedDB, Intersect}
 import oxygen.ui.web.service.HashScroll
 import oxygen.ui.web.style.Breakpoints
 import oxygen.ui.web.style.OxygenColorSystem.*
 import zio.http.{Path, QueryParams}
+
+/** Test sheet exercising the composable media-query DSL (OXY-158). */
+object MediaDslTestSheet extends oxygen.ui.web.create.StyleSheetBuilder {
+  import oxygen.ui.web.create.{*, given}
+
+  object Box extends Class("mq-test-box") {
+    selector(
+      display.flex,
+      flexDirection.column,
+    )
+    // md and up → row. Authored with the ordinary selector DSL, no raw @media strings.
+    media(MediaQuery.mdUp) {
+      selector(flexDirection.row)
+    }
+    // nested media blocks AND together
+    media(MediaQuery.mdUp) {
+      media(MediaQuery.landscape) {
+        selector(gap := "8px")
+      }
+    }
+  }
+
+  override val compiled: StyleSheet = StyleSheet.derived[MediaDslTestSheet.type]
+}
 
 /** Combined Scala.js suite (single main) for oxygen-ui-web pure logic. */
 object OxygenColorSystemSpec extends OxygenSpecDefault {
@@ -133,6 +157,31 @@ object OxygenColorSystemSpec extends OxygenSpecDefault {
           val css = MediaCSS.mdUp(".x { display: none; }")
           assertTrue(css.contains("@media (min-width: 768px)")) &&
           assertTrue(css.contains(".x { display: none; }"))
+        },
+      ),
+      suite("MediaQuery DSL (OXY-158)")(
+        test("MediaQuery renders conditions") {
+          assertTrue(MediaQuery.minWidth(768).query == "(min-width: 768px)") &&
+          assertTrue(MediaQuery.mdUp.query == "(min-width: 768px)") &&
+          assertTrue(MediaQuery.belowMd.query == "(max-width: 767px)") &&
+          assertTrue(MediaQuery.prefersDark.query == "(prefers-color-scheme: dark)")
+        },
+        test("MediaQuery composes with and/or") {
+          assertTrue((MediaQuery.mdUp && MediaQuery.landscape).query == "(min-width: 768px) and (orientation: landscape)") &&
+          assertTrue((MediaQuery.print || MediaQuery.screen).query == "print, screen") &&
+          assertTrue(MediaQuery.between(768, 1024).query == "(min-width: 768px) and (max-width: 1023px)")
+        },
+        test("media() block compiles to an @media wrapper around the selector rule") {
+          val css = MediaDslTestSheet.compiled.body()
+          // base rule is unwrapped
+          assertTrue(css.contains(".mq-test-box")) &&
+          assertTrue(css.contains("flex-direction: column;")) &&
+          // responsive rule is wrapped in @media
+          assertTrue(css.contains("@media (min-width: 768px)")) &&
+          assertTrue(css.contains("flex-direction: row;")) &&
+          // nested media blocks AND together
+          assertTrue(css.contains("@media (min-width: 768px) and (orientation: landscape)")) &&
+          assertTrue(css.contains("gap: 8px;"))
         },
       ),
       suite("Memo")(

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -50,7 +50,7 @@ __build_main() {
 
       printf "\n=====| Generating Scripts |=====\n\n"
       java -jar target/artifacts/jars/example-web-server.jar --: generate target/artifacts/scripts/example-web-server.sh --oxygen-args \
-           -f=example/apps/web-server/src/main/resources/local.json
+           -f=example/apps/web-server/config/local.yaml
       __detected_error_while "generating scripts" || return 1
 
       printf "\n=====| Sourcing Scripts |=====\n\n"

--- a/scripts/run-example-web.sh
+++ b/scripts/run-example-web.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Run the Oxygen example web server locally, in one command.
+#
+# Does three things (each opt-out):
+#   1. brings up the local Postgres (example/docker-compose.yaml, port 5210)
+#   2. builds the Scala.js UI  (example-ui-web/webComp → example/apps/web-server/res/js/main.js)
+#   3. runs the web server     (example-web-server/run, APP_CONFIG=config/local.yaml)
+#
+# Steps 2+3 share a single sbt session, so sbt boots once.
+# Ctrl+C stops the server (and leaves the DB running — stop it with --db-down).
+#
+# Usage (from anywhere):
+#   ./scripts/run-example-web.sh                 # db up + build UI + run  (http://localhost:3210)
+#   ./scripts/run-example-web.sh --no-web-comp   # skip the UI build (res/js already built)
+#   ./scripts/run-example-web.sh --full          # fullLinkJS UI build (slower, optimized)
+#   ./scripts/run-example-web.sh --clean         # sbt clean first
+#   ./scripts/run-example-web.sh --no-db         # don't touch docker (DB already up elsewhere)
+#   ./scripts/run-example-web.sh --db-down       # just stop the docker DB and exit
+#
+# Env:
+#   APP_CONFIG   config file (default: example/apps/web-server/config/local.yaml)
+#   PORT         only used for the "open me" message (default: read from config, else 3210)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+COMPOSE_FILE="${ROOT_DIR}/example/docker-compose.yaml"
+CONFIG="${APP_CONFIG:-${ROOT_DIR}/example/apps/web-server/config/local.yaml}"
+
+# --- args ---------------------------------------------------------------------
+
+do_db=true
+do_db_down=false
+do_web_comp=true
+do_clean=false
+full=false
+
+usage() { sed -n '/^# Run the Oxygen/,/^#   PORT /p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+
+for arg in "$@"; do
+  case "${arg}" in
+    --no-db)        do_db=false ;;
+    --db-down)      do_db_down=true ;;
+    --no-web-comp)  do_web_comp=false ;;
+    --clean)        do_clean=true ;;
+    --full)         full=true ;;
+    -h | --help)    usage; exit 0 ;;
+    *) echo "error: unknown arg: ${arg}" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || { echo "error: required command not found: $1" >&2; exit 1; }
+}
+
+# --- --db-down short-circuit --------------------------------------------------
+
+if [[ "${do_db_down}" == true ]]; then
+  require_cmd docker
+  echo "🛑 stopping example DB"
+  docker compose -f "${COMPOSE_FILE}" down
+  exit 0
+fi
+
+# --- config sanity ------------------------------------------------------------
+
+[[ -f "${CONFIG}" ]] || { echo "error: config not found: ${CONFIG}" >&2; exit 1; }
+
+# port is only for the friendly URL; read http.port from config, fall back to 3210.
+read_port() {
+  awk '
+    /^http:[[:space:]]*$/ { in_http = 1; next }
+    /^[^[:space:]#]/      { in_http = 0 }
+    in_http && $1 == "port:" { v = $2; gsub(/["\047]/, "", v); print v; exit }
+  ' "${CONFIG}"
+}
+PORT="${PORT:-$(read_port || true)}"
+PORT="${PORT:-3210}"
+
+# --- 1. docker db -------------------------------------------------------------
+
+if [[ "${do_db}" == true ]]; then
+  require_cmd docker
+  echo "🐘 ensuring example Postgres is up (docker compose up -d)"
+  docker compose -f "${COMPOSE_FILE}" up -d
+fi
+
+# --- 2. build the UI (its own sbt invocation) ---------------------------------
+#
+# NOTE: webComp is a greedy sbt *input task* (spaceDelimited(...).parsed) — if it shares a
+# command line with anything after it, it eats that as its own argument. So it CANNOT be
+# combined with example-web-server/run in one `sbt "a" "b"` call (run would silently never
+# execute). Build here, run below, as two separate invocations. The persistent sbt server
+# keeps the second one fast.
+
+require_cmd sbt
+cd "${ROOT_DIR}"
+
+build_cmds=()
+[[ "${do_clean}" == true ]] && build_cmds+=("clean")
+if [[ "${do_web_comp}" == true ]]; then
+  if [[ "${full}" == true ]]; then
+    build_cmds+=("example-ui-web/webComp --full")
+  else
+    build_cmds+=("example-ui-web/webComp")
+  fi
+fi
+
+if [[ ${#build_cmds[@]} -gt 0 ]]; then
+  echo
+  echo "🔨 building UI: sbt ${build_cmds[*]}"
+  echo "    (first run compiles a lot and may sit quietly for a few minutes — not a hang)"
+  sbt "${build_cmds[@]}"
+fi
+
+# --- 3. run the server (its own sbt invocation; blocks until Ctrl+C) ----------
+
+echo
+echo "🚀 starting example web server"
+echo "    config: ${CONFIG}"
+echo "    sbt:    example-web-server/run"
+echo
+echo "    It's up when you see:  web-server started on port ${PORT}"
+echo "    Then open http://localhost:${PORT}  (Ctrl+C stops it; DB stays up — --db-down to stop that)"
+echo
+
+export APP_CONFIG="${CONFIG}"
+exec sbt "example-web-server/run"


### PR DESCRIPTION
## OXY-158 — Media query support in the stylesheet DSL

Ticket: https://kr-oxygen.atlassian.net/browse/OXY-158

### Problem
Oxygen has a nice, composable stylesheet DSL, but **media queries were a raw-string one-off**: `MediaCSS` + hand-written `@media { ... }` blocks (`ColumnsStyle`, `HolyGrail.responsiveSheet`, inline strings in `Motion`/`Tooltip`) that bypass the DSL entirely. `StyleSheet.compile` had no `@media` support at all.

### What this does
Makes responsive styles first-class — written with the same selector DSL as everything else.

- **`MediaQuery`** (`create/MediaQuery.scala`): composable condition type — `minWidth/maxWidth/minHeight/maxHeight`, breakpoint helpers (`smUp`/`mdUp`/`lgUp`/`xlUp`, `below*`, `between`), `prefersDark`/`prefersLight`, `portrait`/`landscape`, `reducedMotion`, `canHover`/`pointer`, `screen`/`print`, `&&`/`and`, `||`/`or`, and a `raw` escape hatch.
- **`media(query){ ... }`** (`create/media.scala`): DSL block that tags every rule emitted inside with the query (scoped `MutableAdder`); nests/composes with existing selectors — nested blocks AND together.
- **`StyleSheet.compile`** now threads `Option[MediaQuery]` through the leaf model and emits correct `@media (...) { selector { ... } }`, merging consecutive same-query rules into one block.
- **Dogfooded**: `OxygenStyleSheet` h1 shrinks below `md`; new **showcase page** (`MediaQueryPage`) built entirely with the DSL (reflow + responsive visibility), wired into the example app nav.
- **Back-compat**: `MediaCSS` stays functional with a scaladoc pointer to the new DSL (repo builds with `-Werror -deprecation`, so its live raw call sites can't carry `@deprecated`). No existing call site changed.

### Emitted CSS (from tests)
```
.mq-test-box { display: flex; flex-direction: column; }
@media (min-width: 768px) { .mq-test-box { flex-direction: row; } }
@media (min-width: 768px) and (orientation: landscape) { .mq-test-box { gap: 8px; } }
```

### Verification
- `oxygen-ui-web/compile` ✓, `example-ui-web/compile` ✓, `oxygen-ui-web/test` ✓ (48 passed, 3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YxWKdsz97QT9BD7AdpSq6