### PR TITLE
OXY-154: harden ColorModePicker into a standalone Light/Dark/System component

### DIFF
--- a/docs/docs/ui/builders.md
+++ b/docs/docs/ui/builders.md
@@ -222,7 +222,37 @@ ThemePicker(OxygenThemes.graphiteFamilyPacks)  // filter to a pack family
 
 Both are self-contained (backed by a shared `GlobalState` seeded from the stored value): they
 reflect the current selection and call `ColorMode.setAndPersist` / `Theme.applyAndPersist` on
-select. They do not re-highlight on cross-tab changes until the page re-renders.
+select.
+
+**`ColorModePicker`** is a first-class, standalone Light/Dark/System control — independent of the
+theme-pack machinery (depends only on the `ColorMode` service). It is a config builder (à la
+`ToggleThumb` / `HorizontalRadio`):
+
+```scala
+ColorModePicker()                    // segmented radiogroup (default)
+ColorModePicker.compact              // single icon button that cycles modes (top-bar friendly)
+ColorModePicker.segmentedWithIcons   // segmented + Light/Dark/System glyphs
+ColorModePicker().lightDarkOnly      // drop the System option
+ColorModePicker().large.label("Theme")
+```
+
+- **a11y:** segmented is a `role=radiogroup` with `role=radio` + `aria-checked` per option, roving
+  `tabindex`, and keyboard nav (Left/Up = prev, Right/Down = next, Home/End = first/last with wrap,
+  Space/Enter select) that moves selection **and** DOM focus together. Compact is a native
+  `<button>` with a descriptive `aria-label`/`title`.
+- **Live cross-tab highlight (opt-in):** by default the highlight reflects the mode at render time.
+  Wire `ColorModePicker.syncAcrossTabs` once (e.g. from `prePageLoad`) to have every mounted picker
+  re-highlight on cross-tab / programmatic `ColorMode` changes:
+
+  ```scala
+  override protected def prePageLoad: RIO[Env & Scope, Unit] =
+    ColorTheme.install *> ColorModePicker.syncAcrossTabs
+  ```
+
+  (For labeled *form* contexts, use the generic `HorizontalRadio.form[ColorMode.Mode]` instead — a
+  dedicated dropdown variant is intentionally omitted.)
+
+`ThemePicker` does not re-highlight on cross-tab changes until the page re-renders.
 
 ### Mobile / viewport
 

--- a/docs/docs/ui/builders.md
+++ b/docs/docs/ui/builders.md
@@ -186,6 +186,19 @@ Do not reinvent a partial list of sheets unless you know which ones you can drop
 
 ### Theme + color mode
 
+**Preferred:** one combinator wires both color mode (`ColorMode`) and theme pack (`Theme`) — apply
+stored preferences first-paint, then subscribe both to their cross-tab channels:
+
+```scala
+import oxygen.ui.web.service.ColorTheme
+
+override protected def prePageLoad: RIO[Env & Scope, Unit] =
+  ColorTheme.install
+```
+
+`ColorTheme.applyStored` (apply only, no cross-tab subscription) and the underlying
+`ColorMode.*` / `Theme.*` methods remain available for manual wiring:
+
 ```scala
 import oxygen.ui.web.service.{ColorMode, Theme}
 
@@ -195,6 +208,21 @@ override protected def prePageLoad: RIO[Env & Scope, Unit] =
     ColorMode.subscribeCrossTab *>
     Theme.subscribeCrossTab
 ```
+
+**Pickers (UI):** drop-in reusable widgets — no page state to wire:
+
+```scala
+import oxygen.ui.web.component.{ColorModePicker, ThemePicker}
+
+ColorModePicker()                              // Light / Dark / System segmented control
+ColorModePicker(label = Some("Color mode"))
+ThemePicker()                                  // all OxygenThemes packs, as selectable cards
+ThemePicker(OxygenThemes.graphiteFamilyPacks)  // filter to a pack family
+```
+
+Both are self-contained (backed by a shared `GlobalState` seeded from the stored value): they
+reflect the current selection and call `ColorMode.setAndPersist` / `Theme.applyAndPersist` on
+select. They do not re-highlight on cross-tab changes until the page re-renders.
 
 ### Mobile / viewport
 

--- a/docs/docs/ui/index.md
+++ b/docs/docs/ui/index.md
@@ -44,7 +44,7 @@ import oxygen.ui.web.component.*
 import oxygen.ui.web.create.{*, given}
 import oxygen.ui.web.layout.* // HolyGrail, CenteredCard
 import oxygen.ui.web.defaults.* // coreOxygenStyleSheets
-import oxygen.ui.web.service.{ColorMode, Theme}
+import oxygen.ui.web.service.ColorTheme // unified color-mode + theme-pack facade
 ```
 
 Prefer imports over fully-qualified paths at call sites.
@@ -58,10 +58,7 @@ object MyUI extends PageApp[MyEnv] {
     coreOxygenStyleSheets // reset + theme vars + core chrome
 
   override protected def prePageLoad: RIO[MyEnv & Scope, Unit] =
-    ColorMode.applyStoredOrSystem *>
-      Theme.applyStoredOrDefault *>
-      ColorMode.subscribeCrossTab *>
-      Theme.subscribeCrossTab
+    ColorTheme.install // apply stored mode + pack, then keep both in sync across tabs
 
   override val pages: ArraySeq[RoutablePage[MyEnv]] = ArraySeq(
     HomePage,

--- a/example/apps/ui-electron/src/main/scala/oxygen/example/ui/electron/Renderer.scala
+++ b/example/apps/ui-electron/src/main/scala/oxygen/example/ui/electron/Renderer.scala
@@ -4,7 +4,7 @@ import oxygen.example.ui.electron.page as P
 import oxygen.ui.web.*
 import oxygen.ui.web.create.*
 import oxygen.ui.web.defaults.*
-import oxygen.ui.web.service.{ColorMode, Theme}
+import oxygen.ui.web.service.ColorTheme
 import scala.collection.immutable.ArraySeq
 import scala.scalajs.js.annotation.JSExportTopLevel
 import zio.*
@@ -30,8 +30,7 @@ object Renderer extends PageApp[Renderer.Env] {
     coreOxygenStyleSheets
 
   override protected def prePageLoad: RIO[Env & Scope, Unit] =
-    ColorMode.applyStoredOrSystem *>
-      Theme.applyStoredOrDefault
+    ColorTheme.applyStored
 
   override val pages: ArraySeq[RoutablePage[Env]] = ArraySeq(
     P.IndexPage,

--- a/example/apps/ui/src/main/scala/oxygen/example/ui/UIMain.scala
+++ b/example/apps/ui/src/main/scala/oxygen/example/ui/UIMain.scala
@@ -9,7 +9,7 @@ import oxygen.ui.web.*
 import oxygen.ui.web.apispec.ApiSpecPage
 import oxygen.ui.web.create.*
 import oxygen.ui.web.defaults.*
-import oxygen.ui.web.service.{ColorMode, LocalStorage, Theme}
+import oxygen.ui.web.service.{ColorTheme, LocalStorage}
 import scala.collection.immutable.ArraySeq
 import zio.*
 
@@ -33,10 +33,7 @@ object UIMain extends PageApp[UIMain.Env] {
     coreOxygenStyleSheets
 
   override protected def prePageLoad: RIO[Env & Scope, Unit] =
-    ColorMode.applyStoredOrSystem *>
-      Theme.applyStoredOrDefault *>
-      ColorMode.subscribeCrossTab *>
-      Theme.subscribeCrossTab
+    ColorTheme.install
 
   override val pages: ArraySeq[RoutablePage[Env]] = ArraySeq(
     P.index.IndexPage,

--- a/example/apps/ui/src/main/scala/oxygen/example/ui/page/showcase/pages/KitchenSinkPage.scala
+++ b/example/apps/ui/src/main/scala/oxygen/example/ui/page/showcase/pages/KitchenSinkPage.scala
@@ -4,7 +4,6 @@ import oxygen.example.ui.page.showcase.ShowcaseLayout
 import oxygen.ui.web.*
 import oxygen.ui.web.component.*
 import oxygen.ui.web.create.{*, given}
-import oxygen.ui.web.service.ColorMode
 import zio.*
 
 object KitchenSinkPage extends RoutablePage.NoParams[Any] {
@@ -27,8 +26,7 @@ object KitchenSinkPage extends RoutablePage.NoParams[Any] {
           display.flex,
           gap := S.spacing._2,
           flexWrap.wrap,
-          Button("Theme light").small.subtle.content(onClick := ColorMode.setAndPersist(ColorMode.Mode.Light)),
-          Button("Theme dark").small.subtle.content(onClick := ColorMode.setAndPersist(ColorMode.Mode.Dark)),
+          ColorModePicker(), // OXY-154: reusable picker
           Button("Open modal").small.content(onClick := state.update(_.copy(modal = Some(())))),
           Button("Toast").small.informational.content(onClick := PageMessages.add(PageMessage.info("Kitchen sink toast"))),
         ),

--- a/example/apps/ui/src/main/scala/oxygen/example/ui/page/showcase/pages/ShellPage.scala
+++ b/example/apps/ui/src/main/scala/oxygen/example/ui/page/showcase/pages/ShellPage.scala
@@ -4,7 +4,6 @@ import oxygen.example.ui.page.showcase.ShowcaseLayout
 import oxygen.ui.web.*
 import oxygen.ui.web.component.*
 import oxygen.ui.web.create.{*, given}
-import oxygen.ui.web.service.ColorMode
 
 object ShellPage extends ShowcaseLayout.SimplePage {
   override val path: Seq[String] = Seq("showcase", "shell")
@@ -14,10 +13,7 @@ object ShellPage extends ShowcaseLayout.SimplePage {
       ShowcaseLayout.note("TopBar + SideBar + scrollable center. Resize viewport for responsive collapse."),
       p("This page is already inside the showcase HolyGrail shell."),
       div(height := S.spacing._3),
-      Button("System theme").small.subtle.content(onClick := ColorMode.setAndPersist(ColorMode.Mode.System)),
-      span(display.inlineBlock, width := S.spacing._2),
-      Button("Light").small.subtle.content(onClick := ColorMode.setAndPersist(ColorMode.Mode.Light)),
-      span(display.inlineBlock, width := S.spacing._2),
-      Button("Dark").small.subtle.content(onClick := ColorMode.setAndPersist(ColorMode.Mode.Dark)),
+      // OXY-154: reusable ColorModePicker
+      ColorModePicker(),
     )
 }

--- a/example/apps/ui/src/main/scala/oxygen/example/ui/page/showcase/pages/ThemePage.scala
+++ b/example/apps/ui/src/main/scala/oxygen/example/ui/page/showcase/pages/ThemePage.scala
@@ -4,19 +4,21 @@ import oxygen.example.ui.page.showcase.ShowcaseLayout
 import oxygen.ui.web.*
 import oxygen.ui.web.component.*
 import oxygen.ui.web.create.{*, given}
-import oxygen.ui.web.service.{ColorMode, Theme}
-import oxygen.ui.web.style.OxygenThemes
 import zio.*
 
+/**
+  * OXY-154: this page is now a thin consumer of the reusable [[ColorModePicker]] / [[ThemePicker]]
+  * helpers — the hand-rolled mode toggle + pack-card grid were extracted into those widgets.
+  */
 object ThemePage extends RoutablePage.NoParams[Any] {
-  final case class PageState(activeId: String = OxygenThemes.default.id)
+
+  override type PageState = Unit
 
   override val path: Seq[String] = Seq("showcase", "theme")
-  override def title(s: PageState): String = "Theme studio"
-  override def initialLoad(params: Unit): ZIO[Scope, UIError, PageState] =
-    Theme.currentId.map(PageState(_))
-  override def postLoad(state: WidgetState[PageState], initialState: PageState): ZIO[Scope, UIError, Unit] = ZIO.unit
-  override protected def component(state: WidgetState[PageState], renderState: PageState): WidgetS[PageState] =
+  override def title(s: Unit): String = "Theme studio"
+  override def initialLoad(params: Unit): ZIO[Scope, UIError, Unit] = ZIO.unit
+  override def postLoad(state: WidgetState[Unit], initialState: Unit): ZIO[Scope, UIError, Unit] = ZIO.unit
+  override protected def component(state: WidgetState[Unit], renderState: Unit): WidgetS[Unit] =
     ShowcaseLayout
       .page(ThemePage, "Theme studio")(
         ShowcaseLayout.note(
@@ -24,106 +26,21 @@ object ThemePage extends RoutablePage.NoParams[Any] {
             "plus surface personalities (Aurora / Ember / Violet / Ocean). " +
             "Top bar = solid primary + on-primary ink. Light/Dark flips surfaces only.",
         ),
-        // mode
+        // mode — reusable picker
         div(
-          display.flex,
-          alignItems.center,
-          gap := S.spacing._2,
-          flexWrap.wrap,
           marginBottom := S.spacing._5,
-          span(color := S.color.fg.moderate, fontSize := S.fontSize._2, "Color mode"),
-          Button("Light").small.subtle.content(onClick := ColorMode.setAndPersist(ColorMode.Mode.Light)),
-          Button("Dark").small.subtle.content(onClick := ColorMode.setAndPersist(ColorMode.Mode.Dark)),
-          Button("System").small.subtle.content(onClick := ColorMode.setAndPersist(ColorMode.Mode.System)),
+          ColorModePicker(label = Some("Color mode")),
         ),
         h3("Oxygen theme packs", marginBottom := S.spacing._3),
         p(
           color := S.color.fg.moderate,
           fontSize := S.fontSize._2,
           marginBottom := S.spacing._4,
-          s"Active: ${OxygenThemes.byId.get(renderState.activeId).map(_.name).getOrElse(renderState.activeId)}. Tell us which pack becomes the framework default.",
+          "Pick a pack — applied + persisted live. Tell us which pack becomes the framework default.",
         ),
-        div(
-          display.flex,
-          flexDirection.column,
-          gap := S.spacing._3,
-          Widget.foreach(OxygenThemes.all.toList) { pack =>
-            val on = pack.id == renderState.activeId
-            div(
-              display.flex,
-              flexDirection.column,
-              gap := S.spacing._3,
-              padding := S.spacing._4,
-              borderRadius := S.borderRadius._4,
-              border(2.px, "solid", if on then S.color.primary.standard else S.color.bg.layerThree),
-              backgroundColor := S.color.bg.layerOne,
-              // header row
-              div(
-                display.flex,
-                alignItems.center,
-                justifyContent.spaceBetween,
-                gap := S.spacing._3,
-                flexWrap.wrap,
-                div(
-                  div(fontWeight := "700", fontSize := S.fontSize._5, color := S.color.fg.default, pack.name),
-                  div(fontSize := S.fontSize._2, color := S.color.fg.moderate, marginTop := S.spacing._1, pack.blurb),
-                ), {
-                  val label = if on then "Selected" else "Use this theme"
-                  val base = Button(label).small
-                  val btn = if on then base.primary else base.subtle
-                  btn.content(
-                    onClick := (
-                      Theme.applyAndPersist(pack) *>
-                        state.update(_.copy(activeId = pack.id)) *>
-                        PageMessages.schedule(PageMessage.positive(s"Theme: ${pack.name}"), 2.seconds)
-                    ),
-                  )
-                },
-              ),
-              // swatches
-              div(
-                display.flex,
-                gap := S.spacing._2,
-                flexWrap.wrap,
-                themeSwatch("Primary", pack.primarySwatch),
-                themeSwatch("Accent", pack.accentSwatch),
-                themeSwatch("BG", pack.bgSwatch),
-                themeSwatch("Danger", pack.dark.danger),
-                themeSwatch("Success", pack.dark.success),
-              ),
-              // live preview chips using current CSS vars when selected; raw hex chips always
-              div(
-                display.flex,
-                gap := S.spacing._2,
-                flexWrap.wrap,
-                alignItems.center,
-                Button("Primary").small.primary,
-                Button("Accent").small, // default intent
-                Button("Danger").small.negative.subtle,
-                Button("Success").small.positive.subtle,
-                span(color := S.color.fg.subtle, fontSize := S.fontSize._1, "← live tokens (active pack)"),
-              ),
-            )
-          },
-        ),
+        // pack picker — reusable widget renders OxygenThemes.all
+        ThemePicker(),
       )
-
-  private def themeSwatch(label: String, hex: String): Widget =
-    div(
-      display.flex,
-      flexDirection.column,
-      alignItems.center,
-      gap := S.spacing._1,
-      div(
-        width := 40.px,
-        height := 40.px,
-        borderRadius := S.borderRadius._3,
-        backgroundColor := hex,
-        border(1.px, "solid", S.color.bg.layerThree),
-      ),
-      span(fontSize := S.fontSize._1, color := S.color.fg.subtle, label),
-      span(fontSize := S.fontSize._1, color := S.color.fg.minimal, hex),
-    )
 }
 
 /** Full icon catalog + color samples. */

--- a/example/apps/ui/src/main/scala/oxygen/example/ui/page/showcase/pages/ThemePage.scala
+++ b/example/apps/ui/src/main/scala/oxygen/example/ui/page/showcase/pages/ThemePage.scala
@@ -26,10 +26,29 @@ object ThemePage extends RoutablePage.NoParams[Any] {
             "plus surface personalities (Aurora / Ember / Violet / Ocean). " +
             "Top bar = solid primary + on-primary ink. Light/Dark flips surfaces only.",
         ),
-        // mode — reusable picker
+        // mode — reusable picker, shown in its several variants
+        h3("Color mode picker", marginBottom := S.spacing._3),
+        p(
+          color := S.color.fg.moderate,
+          fontSize := S.fontSize._2,
+          marginBottom := S.spacing._4,
+          "Standalone Light/Dark/System control (independent of theme packs). " +
+            "Keyboard: arrows / Home / End move + select; Space/Enter select. " +
+            "All instances share one persisted preference.",
+        ),
         div(
+          display.flex,
+          flexDirection.column,
+          gap := S.spacing._4,
           marginBottom := S.spacing._5,
-          ColorModePicker(label = Some("Color mode")),
+          // default segmented, with a leading caption
+          ColorModePicker(label = Some("Segmented")),
+          // segmented with icons
+          ColorModePicker.segmentedWithIcons.label("With icons"),
+          // Light/Dark only (no System)
+          ColorModePicker().lightDarkOnly.label("Light / Dark only"),
+          // compact icon cycle button (top-bar style)
+          ColorModePicker.compact.label("Compact"),
         ),
         h3("Oxygen theme packs", marginBottom := S.spacing._3),
         p(

--- a/modules/ui/web/src/main/scala/oxygen/ui/web/component/ColorModePicker.scala
+++ b/modules/ui/web/src/main/scala/oxygen/ui/web/component/ColorModePicker.scala
@@ -61,7 +61,8 @@ object ColorModePicker {
           backgroundColor.dynamic := S.color.bg.layerTwo,
           backgroundColor.dynamic.hover := S.color.bg.layerThree,
           borderColor.dynamic := S.color.bg.layerThree,
-        ),
+        )
+      ,
       mode.pretty,
       onClick := (ColorMode.setAndPersist(mode) *> st.set(mode)),
     )

--- a/modules/ui/web/src/main/scala/oxygen/ui/web/component/ColorModePicker.scala
+++ b/modules/ui/web/src/main/scala/oxygen/ui/web/component/ColorModePicker.scala
@@ -1,0 +1,94 @@
+package oxygen.ui.web.component
+
+import org.scalajs.dom.window
+import oxygen.ui.web.*
+import oxygen.ui.web.create.{*, given}
+import oxygen.ui.web.service.ColorMode
+
+/**
+  * Reusable, drop-in color-mode picker (Light / Dark / System).
+  *
+  * Self-contained: backed by a shared [[GlobalState]] seeded from the stored preference, so it
+  * reflects the current mode and can be dropped into any page without wiring page state. Clicking
+  * an option calls [[ColorMode.setAndPersist]] (persists + rebinds `data-color-mode` + notifies
+  * other tabs) and updates the highlight.
+  *
+  * a11y: `role=radiogroup` container, `role=radio` + `aria-checked` per option.
+  *
+  * {{{
+  * ColorModePicker()                 // just the segmented control
+  * ColorModePicker(label = "Color mode".some)
+  * }}}
+  *
+  * Known limitation (by design, OXY-154): the highlight does not live-update on cross-tab /
+  * programmatic mode changes until the page re-renders. Cross-tab *application* still works via
+  * `ColorTheme.install` / `ColorMode.subscribeCrossTab`.
+  */
+object ColorModePicker {
+
+  private val options: Seq[ColorMode.Mode] =
+    Seq(ColorMode.Mode.Light, ColorMode.Mode.Dark, ColorMode.Mode.System)
+
+  private def readStored: ColorMode.Mode =
+    Option(window.localStorage.getItem(ColorMode.storageKey)).flatMap(ColorMode.parse).getOrElse(ColorMode.Mode.System)
+
+  private object ModeState extends GlobalState[ColorMode.Mode]("ColorModePicker")(readStored)
+
+  private def option(st: WidgetState[ColorMode.Mode], mode: ColorMode.Mode, current: ColorMode.Mode): Widget = {
+    val selected: Boolean = mode == current
+    span(
+      Widget.raw.htmlAttr("role", "radio"),
+      Widget.raw.htmlAttr("aria-checked", if selected then "true" else "false"),
+      Widget.raw.htmlAttr("tabindex", if selected then "0" else "-1"),
+      display.inlineFlex,
+      alignItems.center,
+      cursor.pointer,
+      userSelect.none,
+      padding(S.spacing._1, S.spacing._3),
+      fontSize := S.fontSize._2,
+      fontWeight := S.fontWeight.semiBold,
+      borderStyle.solid,
+      borderWidth := 1.px,
+      if selected then
+        fragment(
+          color.dynamic := S.color.primary.on,
+          backgroundColor.dynamic := S.color.primary.standard,
+          borderColor.dynamic := S.color.primary.standard,
+        )
+      else
+        fragment(
+          color.dynamic := S.color.fg.default,
+          backgroundColor.dynamic := S.color.bg.layerTwo,
+          backgroundColor.dynamic.hover := S.color.bg.layerThree,
+          borderColor.dynamic := S.color.bg.layerThree,
+        ),
+      mode.pretty,
+      onClick := (ColorMode.setAndPersist(mode) *> st.set(mode)),
+    )
+  }
+
+  /** Segmented Light / Dark / System control. Pass `label` to render a leading caption. */
+  def apply(label: Option[String] = None): Widget =
+    Widget.state[ColorMode.Mode].detach(ModeState) { st =>
+      val current: ColorMode.Mode = st.renderTimeValue
+      div(
+        display.inlineFlex,
+        alignItems.center,
+        gap := S.spacing._2,
+        flexWrap.wrap,
+        label match {
+          case Some(text) => span(text, color := S.color.fg.moderate, fontSize := S.fontSize._2)
+          case None       => Widget.empty
+        },
+        div(
+          Widget.raw.htmlAttr("role", "radiogroup"),
+          Widget.raw.htmlAttr("aria-label", "Color mode"),
+          display.inlineFlex,
+          borderRadius := S.borderRadius._3,
+          overflow.hidden,
+          Widget.foreach(options)(option(st, _, current)),
+        ),
+      )
+    }
+
+}

--- a/modules/ui/web/src/main/scala/oxygen/ui/web/component/ColorModePicker.scala
+++ b/modules/ui/web/src/main/scala/oxygen/ui/web/component/ColorModePicker.scala
@@ -225,6 +225,19 @@ object ColorModePicker {
   //      Public entry points (backward compatible)
   // ////////////////////////////////////////////////////////////////////////////////////////////
 
+  /**
+    * Per-instance id counter (scala.js is single-threaded, so a plain `var` is safe).
+    * Guarantees every default-configured picker gets a document-unique `idPrefix`, so multiple
+    * pickers on one page don't emit colliding option ids (which would break roving-tabindex focus
+    * and produce invalid duplicate-id HTML). An explicit `.idPrefix(...)` still overrides this.
+    */
+  private var instanceCounter: Long = 0L
+  private def freshIdPrefix(): String = {
+    val n = instanceCounter
+    instanceCounter += 1L
+    s"oxygen-color-mode-$n"
+  }
+
   /** Default segmented Light / Dark / System control. Pass `label` to render a leading caption. */
   def apply(label: Option[String] = None): ColorModePicker =
     ColorModePicker(
@@ -233,7 +246,7 @@ object ColorModePicker {
       _label = label,
       _includeSystem = true,
       _showIcons = false,
-      _idPrefix = "oxygen-color-mode",
+      _idPrefix = freshIdPrefix(),
     )
 
   /** Compact single-button cycle control (icon by default), ideal for a top bar. */

--- a/modules/ui/web/src/main/scala/oxygen/ui/web/component/ColorModePicker.scala
+++ b/modules/ui/web/src/main/scala/oxygen/ui/web/component/ColorModePicker.scala
@@ -1,51 +1,141 @@
 package oxygen.ui.web.component
 
-import org.scalajs.dom.window
+import org.scalajs.dom.{document, window, HTMLElement, KeyboardEvent}
 import oxygen.ui.web.*
 import oxygen.ui.web.create.{*, given}
-import oxygen.ui.web.service.ColorMode
+import oxygen.ui.web.service.{Broadcast, ColorMode}
+import zio.*
 
 /**
   * Reusable, drop-in color-mode picker (Light / Dark / System).
   *
-  * Self-contained: backed by a shared [[GlobalState]] seeded from the stored preference, so it
-  * reflects the current mode and can be dropped into any page without wiring page state. Clicking
-  * an option calls [[ColorMode.setAndPersist]] (persists + rebinds `data-color-mode` + notifies
-  * other tabs) and updates the highlight.
+  * A first-class, standalone widget for switching color mode. It is fully independent of the
+  * theme-pack machinery ([[ThemePicker]] / `OxygenThemes` / `Theme`) — it depends only on the
+  * [[ColorMode]] service and stands on its own.
   *
-  * a11y: `role=radiogroup` container, `role=radio` + `aria-checked` per option.
+  * Self-contained: backed by a shared [[GlobalState]] seeded from the stored [[ColorMode]]
+  * preference, so it reflects the current mode and can be dropped into any page without wiring
+  * page state. Selecting an option calls [[ColorMode.setAndPersist]] (persists + rebinds
+  * `data-color-mode` + notifies other tabs) and updates the highlight.
+  *
+  * Variants (config builder, à la [[ToggleThumb]] / [[HorizontalRadio]]):
+  *   - [[segmented]] (default) — a `role=radiogroup` Light / Dark / System segmented control with
+  *     full keyboard support (arrows / Home / End / Space / Enter) and roving `tabindex`.
+  *   - [[compact]] — a single icon button that cycles modes; ideal for a top bar.
+  * (A form/dropdown variant is intentionally omitted — `HorizontalRadio.form[ColorMode.Mode]`
+  * already covers labeled form contexts.)
+  *
+  * a11y:
+  *   - segmented: `role=radiogroup`, `role=radio` + `aria-checked` per option, roving `tabindex`,
+  *     keyboard navigation that moves selection + DOM focus together.
+  *   - compact: a native `<button>` with a descriptive `aria-label` / `title` announcing the
+  *     current mode and the next action.
+  *
+  * Live updates: by default the highlight reflects the mode at render time. To make it live-update
+  * on cross-tab / programmatic `ColorMode` changes, wire [[ColorModePicker.syncAcrossTabs]] once
+  * (e.g. from `prePageLoad`); it pushes broadcast changes into the shared state and re-renders.
   *
   * {{{
-  * ColorModePicker()                 // just the segmented control
-  * ColorModePicker(label = "Color mode".some)
+  * ColorModePicker()                              // segmented control
+  * ColorModePicker(label = "Color mode".some)     // with a leading caption
+  * ColorModePicker.compact.small                  // icon cycle button for a top bar
+  * ColorModePicker().lightDarkOnly                 // drop the System option
   * }}}
-  *
-  * Known limitation (by design, OXY-154): the highlight does not live-update on cross-tab /
-  * programmatic mode changes until the page re-renders. Cross-tab *application* still works via
-  * `ColorTheme.install` / `ColorMode.subscribeCrossTab`.
   */
-object ColorModePicker {
+final case class ColorModePicker(
+    private val _variant: ColorModePicker.Variant,
+    private val _size: ColorModePicker.Size,
+    private val _label: Option[String],
+    private val _includeSystem: Boolean,
+    private val _showIcons: Boolean,
+    private val _idPrefix: String,
+) extends PWidget.Deferred.Stateless[Any, Nothing] {
 
-  private val options: Seq[ColorMode.Mode] =
-    Seq(ColorMode.Mode.Light, ColorMode.Mode.Dark, ColorMode.Mode.System)
+  import ColorModePicker.*
 
-  private def readStored: ColorMode.Mode =
-    Option(window.localStorage.getItem(ColorMode.storageKey)).flatMap(ColorMode.parse).getOrElse(ColorMode.Mode.System)
+  // ////////////////////////////////////////////////////////////////////////////////////////////
+  //      Config
+  // ////////////////////////////////////////////////////////////////////////////////////////////
 
-  private object ModeState extends GlobalState[ColorMode.Mode]("ColorModePicker")(readStored)
+  def variant(v: Variant): ColorModePicker = copy(_variant = v)
+  def segmented: ColorModePicker = variant(Variant.Segmented)
+  def compact: ColorModePicker = variant(Variant.Compact)
 
-  private def option(st: WidgetState[ColorMode.Mode], mode: ColorMode.Mode, current: ColorMode.Mode): Widget = {
+  def size(s: Size): ColorModePicker = copy(_size = s)
+  def small: ColorModePicker = size(Size.small)
+  def medium: ColorModePicker = size(Size.medium)
+  def large: ColorModePicker = size(Size.large)
+
+  def label(text: String): ColorModePicker = copy(_label = Some(text))
+  def label(text: Option[String]): ColorModePicker = copy(_label = text)
+  def noLabel: ColorModePicker = copy(_label = None)
+
+  def includeSystem(b: Boolean): ColorModePicker = copy(_includeSystem = b)
+  def lightDarkOnly: ColorModePicker = includeSystem(false)
+
+  def showIcons(b: Boolean): ColorModePicker = copy(_showIcons = b)
+  def withIcons: ColorModePicker = showIcons(true)
+  def noIcons: ColorModePicker = showIcons(false)
+
+  def idPrefix(p: String): ColorModePicker = copy(_idPrefix = p)
+
+  private def modes: List[ColorMode.Mode] = Logic.options(_includeSystem)
+
+  // ////////////////////////////////////////////////////////////////////////////////////////////
+  //      Render
+  // ////////////////////////////////////////////////////////////////////////////////////////////
+
+  override protected def build: PWidget[Any, Nothing, Any, Nothing] =
+    _variant match {
+      case Variant.Segmented => renderSegmented
+      case Variant.Compact   => renderCompact
+    }
+
+  private def select(st: WidgetState[ColorMode.Mode], mode: ColorMode.Mode): UIO[Unit] =
+    ColorMode.setAndPersist(mode) *> st.set(mode)
+
+  private def optionId(mode: ColorMode.Mode): String =
+    s"${_idPrefix}-${mode.lower}"
+
+  private def focusOption(mode: ColorMode.Mode): UIO[Unit] =
+    ZIO.succeed {
+      Option(document.getElementById(optionId(mode))).foreach {
+        case el: HTMLElement => el.focus()
+        case _               => ()
+      }
+    }
+
+  private def iconWidget(mode: ColorMode.Mode): Widget =
+    Logic.iconFor(mode).size(_size.iconPx).decorativeIcon
+
+  private def leadingLabel: Widget =
+    _label match {
+      case Some(text) => span(text, color := S.color.fg.moderate, fontSize := _size.fontSize)
+      case None       => Widget.empty
+    }
+
+  // --- Segmented -------------------------------------------------------------------------------
+
+  private def segmentedOption(
+      st: WidgetState[ColorMode.Mode],
+      mode: ColorMode.Mode,
+      current: ColorMode.Mode,
+  ): Widget = {
     val selected: Boolean = mode == current
     span(
+      id := optionId(mode),
       Widget.raw.htmlAttr("role", "radio"),
       Widget.raw.htmlAttr("aria-checked", if selected then "true" else "false"),
+      Widget.raw.htmlAttr("aria-label", mode.pretty),
       Widget.raw.htmlAttr("tabindex", if selected then "0" else "-1"),
       display.inlineFlex,
       alignItems.center,
+      gap := S.spacing._2,
       cursor.pointer,
       userSelect.none,
-      padding(S.spacing._1, S.spacing._3),
-      fontSize := S.fontSize._2,
+      outline := "none",
+      padding(_size.padV, _size.padH),
+      fontSize := _size.fontSize,
       fontWeight := S.fontWeight.semiBold,
       borderStyle.solid,
       borderWidth := 1.px,
@@ -63,33 +153,190 @@ object ColorModePicker {
           borderColor.dynamic := S.color.bg.layerThree,
         )
       ,
+      if _showIcons then iconWidget(mode) else Widget.empty,
       mode.pretty,
-      onClick := (ColorMode.setAndPersist(mode) *> st.set(mode)),
+      onClick := select(st, mode),
     )
   }
 
-  /** Segmented Light / Dark / System control. Pass `label` to render a leading caption. */
-  def apply(label: Option[String] = None): Widget =
+  private def renderSegmented: Widget =
     Widget.state[ColorMode.Mode].detach(ModeState) { st =>
-      val current: ColorMode.Mode = st.renderTimeValue
+      val current: ColorMode.Mode = Logic.effectiveCurrent(modes, st.renderTimeValue)
       div(
         display.inlineFlex,
         alignItems.center,
         gap := S.spacing._2,
         flexWrap.wrap,
-        label match {
-          case Some(text) => span(text, color := S.color.fg.moderate, fontSize := S.fontSize._2)
-          case None       => Widget.empty
-        },
+        leadingLabel,
         div(
           Widget.raw.htmlAttr("role", "radiogroup"),
-          Widget.raw.htmlAttr("aria-label", "Color mode"),
+          Widget.raw.htmlAttr("aria-label", _label.getOrElse("Color mode")),
           display.inlineFlex,
           borderRadius := S.borderRadius._3,
           overflow.hidden,
-          Widget.foreach(options)(option(st, _, current)),
+          onKeyDown.e.handle { (e: KeyboardEvent) =>
+            Logic.keyToNav(e.key) match {
+              case Some(nav) =>
+                val next = Logic.resolveNav(modes, current, nav)
+                e.preventDefault()
+                if next == current then focusOption(next)
+                else select(st, next) *> focusOption(next)
+              case None => ZIO.unit
+            }
+          },
+          Widget.foreach(modes)(segmentedOption(st, _, current)),
         ),
       )
     }
+
+  // --- Compact ---------------------------------------------------------------------------------
+
+  private def renderCompact: Widget =
+    Widget.state[ColorMode.Mode].detach(ModeState) { st =>
+      val current: ColorMode.Mode = Logic.effectiveCurrent(modes, st.renderTimeValue)
+      val next: ColorMode.Mode = Logic.cycle(modes, current)
+      val describe: String = s"Color mode: ${current.pretty}. Activate to switch to ${next.pretty}."
+      val btn =
+        if _showIcons then Button().iconOnly(Logic.iconFor(current)).subtle
+        else Button(current.pretty).subtle
+      val sized = _size match {
+        case Size.small => btn.small
+        case Size.large => btn.large
+        case _          => btn.medium
+      }
+      div(
+        display.inlineFlex,
+        alignItems.center,
+        gap := S.spacing._2,
+        flexWrap.wrap,
+        leadingLabel,
+        sized.content(
+          Widget.raw.htmlAttr("aria-label", describe),
+          Widget.raw.htmlAttr("title", describe),
+          onClick := select(st, next),
+        ),
+      )
+    }
+
+}
+object ColorModePicker {
+
+  // ////////////////////////////////////////////////////////////////////////////////////////////
+  //      Public entry points (backward compatible)
+  // ////////////////////////////////////////////////////////////////////////////////////////////
+
+  /** Default segmented Light / Dark / System control. Pass `label` to render a leading caption. */
+  def apply(label: Option[String] = None): ColorModePicker =
+    ColorModePicker(
+      _variant = Variant.Segmented,
+      _size = Size.small,
+      _label = label,
+      _includeSystem = true,
+      _showIcons = false,
+      _idPrefix = "oxygen-color-mode",
+    )
+
+  /** Compact single-button cycle control (icon by default), ideal for a top bar. */
+  def compact: ColorModePicker = apply().compact.withIcons
+
+  /** Segmented control with a leading Light/Dark/System icon on each option. */
+  def segmentedWithIcons: ColorModePicker = apply().withIcons
+
+  // ////////////////////////////////////////////////////////////////////////////////////////////
+  //      Shared state
+  // ////////////////////////////////////////////////////////////////////////////////////////////
+
+  private def readStored: ColorMode.Mode =
+    Option(window.localStorage.getItem(ColorMode.storageKey)).flatMap(ColorMode.parse).getOrElse(ColorMode.Mode.System)
+
+  private object ModeState extends GlobalState[ColorMode.Mode]("ColorModePicker")(readStored)
+
+  /**
+    * Opt-in: keep every mounted [[ColorModePicker]] highlight in sync with cross-tab /
+    * programmatic [[ColorMode]] changes for the lifetime of the provided [[Scope]].
+    *
+    * Subscribes to the [[Broadcast]] color-mode channel and pushes changes into the shared state
+    * (which re-renders the current page). Cross-tab *application* of the mode already happens via
+    * `ColorMode.subscribeCrossTab` / `ColorTheme.install`; this only updates the picker's
+    * highlight. Wire once (e.g. from `prePageLoad`).
+    *
+    * {{{
+    * override protected def prePageLoad: RIO[Env & Scope, Unit] =
+    *   ColorTheme.install *> ColorModePicker.syncAcrossTabs
+    * }}}
+    */
+  def syncAcrossTabs: URIO[Scope, Unit] =
+    Broadcast.subscribeThemeMode.foreach(ModeState.set).forkScoped.unit
+
+  // ////////////////////////////////////////////////////////////////////////////////////////////
+  //      Config types
+  // ////////////////////////////////////////////////////////////////////////////////////////////
+
+  enum Variant { case Segmented, Compact }
+
+  final case class Size(fontSize: String, padV: String, padH: String, iconPx: Int)
+  object Size {
+    val small: Size = Size(S.fontSize._2, S.spacing._1, S.spacing._3, Icon.Size.sm)
+    val medium: Size = Size(S.fontSize._4, s"calc(${S.spacing._1} * 1.5)", S.spacing._4, Icon.Size.md)
+    val large: Size = Size(S.fontSize._6, S.spacing._2, S.spacing._5, Icon.Size.lg)
+  }
+
+  // ////////////////////////////////////////////////////////////////////////////////////////////
+  //      Pure decision logic (DOM-free, unit-tested)
+  // ////////////////////////////////////////////////////////////////////////////////////////////
+
+  /** Keyboard-navigation intents within a segmented radiogroup. */
+  enum Nav { case Prev, Next, First, Last, Select }
+
+  object Logic {
+
+    /** Ordered options; `System` is included only when `includeSystem`. */
+    def options(includeSystem: Boolean): List[ColorMode.Mode] =
+      if includeSystem then List(ColorMode.Mode.Light, ColorMode.Mode.Dark, ColorMode.Mode.System)
+      else List(ColorMode.Mode.Light, ColorMode.Mode.Dark)
+
+    def iconFor(mode: ColorMode.Mode): Icon =
+      mode match {
+        case ColorMode.Mode.Light  => Icon.sun
+        case ColorMode.Mode.Dark   => Icon.moon
+        case ColorMode.Mode.System => Icon.monitor
+      }
+
+    /** The stored value, clamped into `options` (e.g. `System` stored but excluded => first). */
+    def effectiveCurrent(options: List[ColorMode.Mode], stored: ColorMode.Mode): ColorMode.Mode =
+      if options.contains(stored) then stored else options.headOption.getOrElse(stored)
+
+    /** Map a `KeyboardEvent.key` to a navigation intent, if any. */
+    def keyToNav(key: String): Option[Nav] =
+      key match {
+        case "ArrowLeft" | "Left" | "ArrowUp" | "Up"       => Some(Nav.Prev)
+        case "ArrowRight" | "Right" | "ArrowDown" | "Down" => Some(Nav.Next)
+        case "Home"                                        => Some(Nav.First)
+        case "End"                                         => Some(Nav.Last)
+        case " " | "Spacebar" | "Enter"                    => Some(Nav.Select)
+        case _                                             => None
+      }
+
+    /** Resolve a navigation intent to the target mode (Prev/Next wrap around). */
+    def resolveNav(options: List[ColorMode.Mode], current: ColorMode.Mode, nav: Nav): ColorMode.Mode = {
+      val n = options.size
+      if n == 0 then current
+      else {
+        val idx = math.max(options.indexOf(current), 0)
+        nav match {
+          case Nav.Prev   => options((idx - 1 + n) % n)
+          case Nav.Next   => options((idx + 1) % n)
+          case Nav.First  => options.head
+          case Nav.Last   => options.last
+          case Nav.Select => options(idx)
+        }
+      }
+    }
+
+    /** Next mode in cycle order (wraps) — used by the compact button. */
+    def cycle(options: List[ColorMode.Mode], current: ColorMode.Mode): ColorMode.Mode =
+      resolveNav(options, current, Nav.Next)
+
+  }
 
 }

--- a/modules/ui/web/src/main/scala/oxygen/ui/web/component/ThemePicker.scala
+++ b/modules/ui/web/src/main/scala/oxygen/ui/web/component/ThemePicker.scala
@@ -1,0 +1,114 @@
+package oxygen.ui.web.component
+
+import org.scalajs.dom.window
+import oxygen.ui.web.*
+import oxygen.ui.web.create.{*, given}
+import oxygen.ui.web.service.Theme
+import oxygen.ui.web.style.OxygenThemes
+import oxygen.ui.web.style.OxygenThemes.Pack
+
+/**
+  * Reusable, drop-in theme-pack picker. Renders [[OxygenThemes.all]] (or a filtered `packs` list)
+  * as selectable cards (swatch + name + blurb + selected state) and calls [[Theme.applyAndPersist]]
+  * on select.
+  *
+  * Self-contained: backed by a shared [[GlobalState]] seeded from the stored / current pack, so it
+  * reflects the active pack and can be dropped into any page without wiring page state.
+  *
+  * a11y: `role=radiogroup` container, `role=radio` + `aria-checked` per card.
+  *
+  * {{{
+  * ThemePicker()                                      // all packs
+  * ThemePicker(OxygenThemes.graphiteFamilyPacks)      // graphite family only
+  * }}}
+  *
+  * Known limitation (by design, OXY-154): the highlight does not live-update on cross-tab /
+  * programmatic pack changes until the page re-renders. Cross-tab *application* still works via
+  * `ColorTheme.install` / `Theme.subscribeCrossTab`.
+  */
+object ThemePicker {
+
+  private def readStored: String =
+    Option(window.localStorage.getItem(Theme.storageKey))
+      .flatMap(OxygenThemes.parse)
+      .getOrElse(OxygenThemes.default)
+      .id
+
+  private object PackState extends GlobalState[String]("ThemePicker")(readStored)
+
+  private def swatch(label: String, hex: String): Widget =
+    div(
+      display.flex,
+      flexDirection.column,
+      alignItems.center,
+      gap := S.spacing._1,
+      div(
+        width := 40.px,
+        height := 40.px,
+        borderRadius := S.borderRadius._3,
+        backgroundColor := hex,
+        border(1.px, "solid", S.color.bg.layerThree),
+      ),
+      span(fontSize := S.fontSize._1, color := S.color.fg.subtle, label),
+      span(fontSize := S.fontSize._1, color := S.color.fg.minimal, hex),
+    )
+
+  private def card(st: WidgetState[String], pack: Pack, activeId: String): Widget = {
+    val on: Boolean = pack.id == activeId
+    div(
+      Widget.raw.htmlAttr("role", "radio"),
+      Widget.raw.htmlAttr("aria-checked", if on then "true" else "false"),
+      Widget.raw.htmlAttr("aria-label", pack.name),
+      display.flex,
+      flexDirection.column,
+      gap := S.spacing._3,
+      padding := S.spacing._4,
+      borderRadius := S.borderRadius._4,
+      border(2.px, "solid", if on then S.color.primary.standard else S.color.bg.layerThree),
+      backgroundColor := S.color.bg.layerOne,
+      // header row: name/blurb + apply button
+      div(
+        display.flex,
+        alignItems.center,
+        justifyContent.spaceBetween,
+        gap := S.spacing._3,
+        flexWrap.wrap,
+        div(
+          div(fontWeight := S.fontWeight.bold, fontSize := S.fontSize._5, color := S.color.fg.default, pack.name),
+          div(fontSize := S.fontSize._2, color := S.color.fg.moderate, marginTop := S.spacing._1, pack.blurb),
+        ), {
+          val label = if on then "Selected" else "Use this theme"
+          val base = Button(label).small
+          val btn = if on then base.primary else base.subtle
+          btn.content(onClick := (Theme.applyAndPersist(pack) *> st.set(pack.id)))
+        },
+      ),
+      // swatches
+      div(
+        display.flex,
+        gap := S.spacing._2,
+        flexWrap.wrap,
+        swatch("Primary", pack.primarySwatch),
+        swatch("Accent", pack.accentSwatch),
+        swatch("BG", pack.bgSwatch),
+        swatch("Danger", pack.dark.danger),
+        swatch("Success", pack.dark.success),
+      ),
+    )
+  }
+
+  /** Card list for the given packs (defaults to all Oxygen theme packs). */
+  def apply(packs: Seq[Pack] = OxygenThemes.all): Widget =
+    Widget.state[String].detach(PackState) { st =>
+      val activeId: String = st.renderTimeValue
+      div(
+        Widget.raw.htmlAttr("role", "radiogroup"),
+        Widget.raw.htmlAttr("aria-label", "Theme pack"),
+        display.flex,
+        flexDirection.column,
+        gap := S.spacing._3,
+        Widget.foreach(packs.toList)(card(st, _, activeId)),
+      )
+    }
+
+}

--- a/modules/ui/web/src/main/scala/oxygen/ui/web/defaults/StylesPage.scala
+++ b/modules/ui/web/src/main/scala/oxygen/ui/web/defaults/StylesPage.scala
@@ -3,7 +3,6 @@ package oxygen.ui.web.defaults
 import oxygen.ui.web.*
 import oxygen.ui.web.component.*
 import oxygen.ui.web.create.{*, given}
-import oxygen.ui.web.service.ColorMode
 import zio.{Scope, ZIO}
 
 /**
@@ -50,6 +49,7 @@ object StylesPage extends RoutablePage.NoParams[Any] {
       div(height := 25.px),
     )
 
+  // OXY-154: reusable ColorModePicker replaces the hand-rolled Light/Dark/System buttons.
   private lazy val colorModeToggle: Widget =
     div(
       display.flex,
@@ -59,10 +59,7 @@ object StylesPage extends RoutablePage.NoParams[Any] {
       padding := OxygenStyleVars.spacing._4,
       backgroundColor := OxygenStyleVars.color.bg.layerOne,
       borderRadius := OxygenStyleVars.borderRadius._4,
-      span("Color mode:", color := OxygenStyleVars.color.fg.moderate),
-      Button("Light").small.subtle.content(onClick := ColorMode.setAndPersist(ColorMode.Mode.Light)),
-      Button("Dark").small.subtle.content(onClick := ColorMode.setAndPersist(ColorMode.Mode.Dark)),
-      Button("System").small.subtle.content(onClick := ColorMode.setAndPersist(ColorMode.Mode.System)),
+      ColorModePicker(label = Some("Color mode:")),
     )
 
   /** Quick surface / text / status chips for at-a-glance mode checking. */

--- a/modules/ui/web/src/main/scala/oxygen/ui/web/service/ColorTheme.scala
+++ b/modules/ui/web/src/main/scala/oxygen/ui/web/service/ColorTheme.scala
@@ -1,0 +1,50 @@
+package oxygen.ui.web.service
+
+import zio.*
+
+/**
+  * Unified facade over the two independent color-theme services:
+  *   - [[ColorMode]] — light / dark / system (attr `data-color-mode`, key `oxygen.color-mode`)
+  *   - [[Theme]]     — theme pack / `OxygenThemes` (attr `data-oxygen-theme`, key `oxygen.theme-pack`)
+  *
+  * Replaces the copy-pasted `prePageLoad` snippet:
+  * {{{
+  *   ColorMode.applyStoredOrSystem *>
+  *     Theme.applyStoredOrDefault *>
+  *     ColorMode.subscribeCrossTab *>
+  *     Theme.subscribeCrossTab
+  * }}}
+  * with a single combinator:
+  * {{{
+  *   override protected def prePageLoad: RIO[Env & Scope, Unit] = ColorTheme.install
+  * }}}
+  *
+  * The individual [[ColorMode]] / [[Theme]] methods remain public — the manual form still works.
+  */
+object ColorTheme {
+
+  /**
+    * Apply the stored (or system / default) color mode + theme pack to the live document.
+    * Safe to call first-paint from `prePageLoad`. No cross-tab subscription (see [[install]]).
+    */
+  def applyStored: UIO[Unit] =
+    ColorMode.applyStoredOrSystem *>
+      Theme.applyStoredOrDefault
+
+  /**
+    * Subscribe both color mode + theme pack to their cross-tab [[Broadcast]] channels.
+    * Lives for the provided [[Scope]] (app root / `prePageLoad` is the usual home).
+    */
+  def subscribeCrossTab: URIO[Scope, Unit] =
+    ColorMode.subscribeCrossTab *>
+      Theme.subscribeCrossTab
+
+  /**
+    * One-call bootstrap: apply stored preferences, then keep them in sync across tabs.
+    * Preferred over the manual 4-line snippet.
+    */
+  def install: URIO[Scope, Unit] =
+    applyStored *>
+      subscribeCrossTab
+
+}

--- a/modules/ui/web/src/test/scala/oxygen/ui/web/style/OxygenColorSystemSpec.scala
+++ b/modules/ui/web/src/test/scala/oxygen/ui/web/style/OxygenColorSystemSpec.scala
@@ -3,9 +3,9 @@ package oxygen.ui.web.style
 import java.time.YearMonth
 import oxygen.predef.test.*
 import oxygen.ui.web.{LockState, Memo, PageURL}
-import oxygen.ui.web.component.{ColorPicker, DatePicker, DateTimePicker, Icon, InfiniteScroll, LazySection, Pagination, Progress, SideBar, SortableList, Tabs, TimePicker, TopBar}
+import oxygen.ui.web.component.{ColorModePicker, ColorPicker, DatePicker, DateTimePicker, Icon, InfiniteScroll, LazySection, Pagination, Progress, SideBar, SortableList, Tabs, TimePicker, TopBar}
 import oxygen.ui.web.create.{AnchorId, CSSColor, MediaCSS, Motion}
-import oxygen.ui.web.service.{IndexedDB, Intersect}
+import oxygen.ui.web.service.{ColorMode, IndexedDB, Intersect}
 import oxygen.ui.web.service.HashScroll
 import oxygen.ui.web.style.Breakpoints
 import oxygen.ui.web.style.OxygenColorSystem.*
@@ -381,6 +381,57 @@ object OxygenColorSystemSpec extends OxygenSpecDefault {
           )
           assertTrue(fgBg.exists(_ >= Contrast.aaLarge)) &&
           assertTrue(w.forall(_.ratio > 0))
+        },
+      ),
+      suite("ColorModePicker.Logic")(
+        test("options include/exclude System") {
+          import ColorMode.Mode.*
+          assertTrue(ColorModePicker.Logic.options(true) == List(Light, Dark, System)) &&
+          assertTrue(ColorModePicker.Logic.options(false) == List(Light, Dark))
+        },
+        test("iconFor maps each mode to a distinct icon") {
+          import ColorMode.Mode.*
+          val names = Set(Light, Dark, System).map(ColorModePicker.Logic.iconFor(_).name)
+          assertTrue(names.size == 3) &&
+          assertTrue(ColorModePicker.Logic.iconFor(Light).name == "sun") &&
+          assertTrue(ColorModePicker.Logic.iconFor(Dark).name == "moon")
+        },
+        test("effectiveCurrent clamps a stored mode not in options") {
+          import ColorMode.Mode.*
+          val ld = ColorModePicker.Logic.options(false)
+          assertTrue(ColorModePicker.Logic.effectiveCurrent(ld, Dark) == Dark) &&
+          assertTrue(ColorModePicker.Logic.effectiveCurrent(ld, System) == Light) &&
+          assertTrue(ColorModePicker.Logic.effectiveCurrent(Nil, System) == System)
+        },
+        test("keyToNav maps arrows/home/end/space/enter, ignores others") {
+          import ColorModePicker.Nav.*
+          assertTrue(ColorModePicker.Logic.keyToNav("ArrowLeft").contains(Prev)) &&
+          assertTrue(ColorModePicker.Logic.keyToNav("Up").contains(Prev)) &&
+          assertTrue(ColorModePicker.Logic.keyToNav("ArrowRight").contains(Next)) &&
+          assertTrue(ColorModePicker.Logic.keyToNav("Down").contains(Next)) &&
+          assertTrue(ColorModePicker.Logic.keyToNav("Home").contains(First)) &&
+          assertTrue(ColorModePicker.Logic.keyToNav("End").contains(Last)) &&
+          assertTrue(ColorModePicker.Logic.keyToNav(" ").contains(Select)) &&
+          assertTrue(ColorModePicker.Logic.keyToNav("Enter").contains(Select)) &&
+          assertTrue(ColorModePicker.Logic.keyToNav("a").isEmpty)
+        },
+        test("resolveNav wraps Prev/Next and honors First/Last/Select") {
+          import ColorMode.Mode.*
+          import ColorModePicker.Nav.*
+          val opts = ColorModePicker.Logic.options(true)
+          assertTrue(ColorModePicker.Logic.resolveNav(opts, Light, Prev) == System) &&
+          assertTrue(ColorModePicker.Logic.resolveNav(opts, System, Next) == Light) &&
+          assertTrue(ColorModePicker.Logic.resolveNav(opts, Dark, Next) == System) &&
+          assertTrue(ColorModePicker.Logic.resolveNav(opts, Dark, First) == Light) &&
+          assertTrue(ColorModePicker.Logic.resolveNav(opts, Dark, Last) == System) &&
+          assertTrue(ColorModePicker.Logic.resolveNav(opts, Dark, Select) == Dark)
+        },
+        test("cycle advances with wraparound") {
+          import ColorMode.Mode.*
+          val opts = ColorModePicker.Logic.options(true)
+          assertTrue(ColorModePicker.Logic.cycle(opts, Light) == Dark) &&
+          assertTrue(ColorModePicker.Logic.cycle(opts, Dark) == System) &&
+          assertTrue(ColorModePicker.Logic.cycle(opts, System) == Light)
         },
       ),
     )

--- a/modules/ui/web/src/test/scala/oxygen/ui/web/style/OxygenColorSystemSpec.scala
+++ b/modules/ui/web/src/test/scala/oxygen/ui/web/style/OxygenColorSystemSpec.scala
@@ -394,7 +394,8 @@ object OxygenColorSystemSpec extends OxygenSpecDefault {
           val names = Set(Light, Dark, System).map(ColorModePicker.Logic.iconFor(_).name)
           assertTrue(names.size == 3) &&
           assertTrue(ColorModePicker.Logic.iconFor(Light).name == "sun") &&
-          assertTrue(ColorModePicker.Logic.iconFor(Dark).name == "moon")
+          assertTrue(ColorModePicker.Logic.iconFor(Dark).name == "moon") &&
+          assertTrue(ColorModePicker.Logic.iconFor(System).name == "desktop")
         },
         test("effectiveCurrent clamps a stored mode not in options") {
           import ColorMode.Mode.*

--- a/report/OXY-154-colormode.md
+++ b/report/OXY-154-colormode.md
@@ -1,0 +1,43 @@
+# OXY-154-colormode — Harden ColorModePicker
+
+Branch: `OXY-154-colormode` (stacked on `OXY-154`, PR #296).
+
+## Goal
+Make `ColorModePicker` a first-class standalone Light/Dark/System component: decouple from ThemePicker/pack work, add variants, solid a11y + keyboard nav, react to cross-tab/programmatic ColorMode changes, unit tests, showcase, docs.
+
+## Findings (current ColorModePicker.scala)
+- Single `apply(label)` -> segmented control only. No variants.
+- Uses own `ModeState` GlobalState + own `readStored` (duplicates ColorMode.readStored logic w/ localStorage).
+- a11y: role=radiogroup/radio, aria-checked, tabindex roving present, BUT no keyboard handlers (arrow keys / space) wired.
+- Known limitation documented: highlight does not live-update on cross-tab/programmatic changes (no Broadcast subscribe).
+- Coupling to ThemePicker: shares *pattern* (GlobalState + detach + readStored) but no direct code dependency. Independent already at code level — good.
+
+## Decisions
+- ColorModePicker was already code-independent of ThemePicker (only shared a *pattern*: GlobalState + detach + readStored). Confirmed no import/type coupling. Kept its own shared `ModeState` GlobalState seeded via `ColorMode.storageKey`/`ColorMode.parse` (depends only on `ColorMode` service, never on `Theme`/`OxygenThemes`/`ThemePicker`). => fully standalone.
+- Rewrote as a config case-class extending `PWidget.Deferred.Stateless` (matches ToggleThumb / HorizontalRadio / Icon conventions), so instances are droppable widgets AND fluently configurable. Backward-compat `apply()` / `apply(label = ...)` retained (existing call sites: ThemePage, StylesPage, KitchenSinkPage, ShellPage).
+- Variants: **Segmented** (role=radiogroup, default) + **Compact** (single icon cycle button, top-bar friendly, role=button). Deliberately did NOT add a native `<select>`/dropdown "form" variant — form contexts are already served by the generic `HorizontalRadio.form[ColorMode.Mode]`; a third variant would be over-engineering. Documented.
+- Config knobs: `.small/.medium/.large`, `.label(..)/.noLabel`, `.includeSystem(..)/.lightDarkOnly` (sensible variant: some apps only want Light/Dark), `.withIcons/.noIcons`, `.idPrefix(..)` (multi-instance focus-id disambiguation).
+- Icons: Light=sun, Dark=moon, System=monitor.
+- a11y hardening (segmented): roving `tabindex` (0 on selected, -1 others), `role=radiogroup`+`aria-label`, per-option `role=radio`+`aria-checked`+stable `id`, keyboard nav on the group (Left/Up = prev, Right/Down = next, Home/End = first/last with wrap, Space/Enter select) that selects + moves DOM focus to the new radio. Compact: native `<button>` via Button + descriptive `aria-label`/`title` announcing current mode and next action.
+- Extracted pure decision logic into `ColorModePicker.Logic` (options list, `keyToNav`, `resolveNav` with wraparound, `cycle`) — unit-tested (no DOM).
+- Cross-tab/programmatic live update: added opt-in `ColorModePicker.syncAcrossTabs: URIO[Scope, Unit]` that subscribes to `Broadcast.subscribeThemeMode` and pushes into the shared `ModeState` (via `GlobalState.set`, which re-renders the current page) so the highlight live-updates. Left OFF by default (no behavior change); consumers wire it in `prePageLoad`/`postLoad`. Kept ColorMode's own doc-application subscription untouched. Removed the old "known limitation" caveat since it's now addressable.
+
+## What changed (files)
+- `modules/ui/web/.../component/ColorModePicker.scala` — rewritten as config case-class widget (Segmented + Compact variants), a11y + keyboard nav, `Logic` (pure), `syncAcrossTabs`, `Size`/`Variant`/`Nav`. Backward-compat `apply()` kept.
+- `modules/ui/web/src/test/.../style/OxygenColorSystemSpec.scala` — added `ColorModePicker.Logic` suite (6 tests, all pure/DOM-free).
+- `example/apps/ui/.../showcase/pages/ThemePage.scala` — showcase now demos 4 variants (segmented, with-icons, light/dark-only, compact).
+- `docs/docs/ui/builders.md` — documented variants, a11y, `syncAcrossTabs`, form guidance.
+
+## Verification
+- `oxygen-ui-web/compile` ✅  `example-ui-web/compile` ✅  `oxygen-ui-web/test` ✅ (51 tests, incl. 6 new).
+- `sbt fmt` applied; JGit worktree workaround (`git.gitUncommittedChanges := false`) added temporarily to load sbt, then reverted — NOT committed.
+- No changes to `ColorMode` / `Theme` / `ColorTheme` / `ThemePicker` behavior. Existing `ColorModePicker()` call sites (ThemePage, StylesPage, KitchenSinkPage, ShellPage) unchanged and still compile.
+
+## Assumptions
+- Native `<select>`/dropdown variant intentionally skipped (HorizontalRadio.form covers form contexts) — judged as avoiding over-engineering, not a gap.
+- `syncAcrossTabs` left opt-in (no default wiring) to avoid changing existing app bootstrap behavior; `GlobalState.set` from a forked subscription fiber re-renders the current page (consistent with `ColorMode.subscribeCrossTab`'s scoped-fork pattern). Not exercised in a live browser here — logic is straightforward but unverified at runtime.
+- Keyboard focus management (`document.getElementById(id).focus()` after `st.set`) relies on `set` completing after the re-render patch; matches the framework's synchronous render model but not browser-tested.
+- Multi-instance focus ids share a default `_idPrefix`; `idPrefix(..)` provided for disambiguation. All instances intentionally share one persisted preference (single logical selection).
+
+## CONFIDENCE: 8/10
+Compiles, formatted, all tests green, backward compatible, decoupling verified. Deductions: runtime a11y/keyboard-focus behavior and `syncAcrossTabs` live cross-tab re-highlight are logically sound and unit-tested at the decision-logic level, but not exercised in a real browser this session.

--- a/report/OXY-154.md
+++ b/report/OXY-154.md
@@ -1,0 +1,60 @@
+# OXY-154 — Reusable helper for color theme
+
+Branch: `OXY-154` (worktree). Epic: OXY-133 (`oxygen-ui-rework`).
+
+## Goal
+Single importable, reusable helper for Oxygen's color theme:
+- Unified bootstrap combinator (`service.ColorTheme.install`) replacing the copy-pasted 4-line `prePageLoad` wiring.
+- Reusable `ColorModePicker` (Light/Dark/System) + `ThemePicker` (pack grid) widgets.
+- No new storage keys / packs / CSS vars. Reuse `S.color.*`. a11y.
+- Refactor `ThemePage`/`StylesPage` (and other dup sites). Update docs.
+
+## Key existing pieces (found)
+- `service/ColorMode.scala` — Mode (System/Light/Dark), `applyStoredOrSystem`, `setAndPersist`, `subscribeCrossTab`. storageKey `oxygen.color-mode`, attr `data-color-mode`.
+- `service/Theme.scala` — `applyStoredOrDefault`, `applyAndPersist`, `currentId`, `subscribeCrossTab`. storageKey `oxygen.theme-pack`, attr `data-oxygen-theme`.
+- `style/OxygenThemes.scala` — `Pack`, `all`, `graphiteFamilyPacks`, `byId`, `default`, `parse`.
+- Widget state model: `GlobalState[S]` + `Widget.state[S].detach(globalState){ st => ... }` gives a page-state-independent, drop-in stateful widget. This is the mechanism used for reusable self-contained widgets (see `PageMessagesBottomCorner` w/ `PageLocalState`).
+- Dup sites: `UIMain.prePageLoad` (+ Renderer) bootstrap; mode toggle in `StylesPage`, `ThemePage`, `ShellPage`, `KitchenSinkPage`; pack picker card grid in `ThemePage`.
+
+## Decisions (resolving open questions)
+1. **Facade location/name** → `oxygen.ui.web.service.ColorTheme` (sibling of `ColorMode`/`Theme`). Matches ticket's `service.ColorTheme.install` suggestion. Provides `applyStored`, `subscribeCrossTab`, `install` (= apply + subscribe). Manual forms kept working (nothing removed).
+2. **Picker state** → self-contained via a shared `GlobalState` seeded from stored value, using `.detach`. Drop-in anywhere (inner state = `Any/Nothing`), no page wiring. Reflects current selection; click updates persistence + highlight. (Rejected pure-stateless because ticket wants "reflecting current mode"; rejected page-owned state because it's not drop-in.)
+3. **Mode picker shape** → segmented buttons (3 options Light/Dark/System), inline `S.color.*` tokens, `role=radiogroup` + `role=radio`/`aria-checked`. Not `HorizontalRadio` (that is `StrictEnum`/form-oriented and heavier).
+4. **Pack picker shape** → vertical card list (swatch row + name + blurb + selected state + apply button), same visuals as current `ThemePage`. One variant shipped.
+5. **Pack filter default** → `OxygenThemes.all` (all 10). `packs` param allows filtering (e.g. `OxygenThemes.graphiteFamilyPacks`).
+6. **Broadcast re-highlight** → NO subscription inside widgets (keep simple). Known limitation: cross-tab / programmatic changes don't live-update a picker's cached highlight until re-render/re-seed. Cross-tab *application* of theme still works (services already subscribe via `ColorTheme.install`). Documented.
+7. **Persistence** → keep `localStorage` (via existing `ColorMode`/`Theme`). OXY-143 config service delegation left for later.
+
+## a11y
+- `role=radiogroup` + `aria-label` on container; each option `role=radio` + `aria-checked`. (Ticket hinted `aria-pressed`; radiogroup+aria-checked is the semantically correct pairing for single-select.)
+
+## Work log / files changed
+New:
+- `modules/ui/web/.../service/ColorTheme.scala` — facade: `applyStored`, `subscribeCrossTab`, `install`.
+- `modules/ui/web/.../component/ColorModePicker.scala` — segmented Light/Dark/System, self-contained via `GlobalState`.
+- `modules/ui/web/.../component/ThemePicker.scala` — pack-card grid, `packs` filter, self-contained via `GlobalState`.
+
+Refactored:
+- `example/.../UIMain.scala` — `prePageLoad = ColorTheme.install`.
+- `example/.../electron/Renderer.scala` — `prePageLoad = ColorTheme.applyStored` (no cross-tab sub, matching prior behaviour).
+- `modules/ui/web/.../defaults/StylesPage.scala` — mode buttons → `ColorModePicker`.
+- `example/.../pages/ThemePage.scala` — mode buttons → `ColorModePicker`; pack grid → `ThemePicker`; state simplified to `Unit`.
+- `example/.../pages/ShellPage.scala` — mode buttons → `ColorModePicker`.
+- `example/.../pages/KitchenSinkPage.scala` — light/dark buttons → `ColorModePicker`.
+- `docs/docs/ui/index.md`, `docs/docs/ui/builders.md` — show `ColorTheme.install` + pickers as preferred (manual form kept as fallback).
+
+## Verification
+- `-Werror -Wunused:all` is on. Compiled clean: `oxygen-ui-web`, `example-ui-web`, `oxygen-ui-electron`, `example-ui-electron`.
+- Did NOT run Scala.js test suites (node-based; no logic under existing tests changed). No new tests added — widgets are visual/DOM.
+- Note: sbt-git's jgit `hasUncommittedChanges` throws inside a git *worktree* (unrelated to this change). Verified compile by temporarily setting `git.gitUncommittedChanges := false` in build.sbt, then reverting. A CI checkout (non-worktree) is unaffected.
+
+## Assumptions / notable choices
+- Behaviour parity kept: nothing removed from `ColorMode` / `Theme`; manual wiring still compiles/works.
+- ThemePage lost its per-pack "live token chips" row + toast-on-apply + dynamic "Active: X" text label when extracting into `ThemePicker` (kept the swatch/name/blurb/selected/apply-button essentials the ticket specified). Reasonable trade for a reusable widget; can be added back as `ThemePicker` options if desired.
+- Pickers cache selection in a shared `GlobalState` seeded from `localStorage`; they do NOT subscribe to `Broadcast`, so cross-tab/programmatic changes don't re-highlight until re-render (documented; theme *application* across tabs still works via `ColorTheme.install`).
+- a11y: `role=radiogroup` + `role=radio`/`aria-checked` (semantically correct single-select; ticket's `aria-pressed` hint interpreted as "expose selected state").
+- Electron renderer intentionally uses `applyStored` (not `install`) to preserve its original no-cross-tab behaviour.
+
+## CONFIDENCE: 7.5/10
+- High confidence it compiles and satisfies the ticket's required changes (facade + both pickers + page/doc refactors, no new keys/packs/vars, a11y).
+- Lower confidence on exact visual/UX expectations: pickers not run in a live browser (couldn't launch Scala.js app here); dropped a few ThemePage extras; GlobalState-seed reflection is correct for normal use but has the documented cross-tab-highlight limitation. `HorizontalRadio` could arguably have been reused for the mode picker instead of a bespoke segmented control.


### PR DESCRIPTION
## Summary

Hardens `ColorModePicker` (from OXY-154) into a first-class, **standalone** Light / Dark / System control. It is now fully independent of the theme-pack machinery — it depends only on the `ColorMode` service and stands on its own even if `ThemePicker` didn't exist. `ThemePicker` is unchanged.

> Stacks on **#296** (`OXY-154`). This PR is based on the `OXY-154` branch so the diff shows only the new work. Merge/rebase #296 first.

## What changed
- **Config-builder widget** (à la `ToggleThumb` / `HorizontalRadio`), so instances are droppable widgets *and* fluently configurable. Two variants:
  - **Segmented** (`role=radiogroup`, default)
  - **Compact** — a single icon button that cycles modes (top-bar friendly)
- **Config knobs:** `.small/.medium/.large`, `.label(..)/.noLabel`, `.includeSystem(..)/.lightDarkOnly`, `.withIcons/.noIcons`, `.idPrefix(..)`. Backward-compatible `apply()` / `apply(label = ...)` retained — existing call sites unchanged.
- **a11y hardening:** roving `tabindex`, `role=radio` + `aria-checked` per option, and keyboard nav (Left/Up = prev, Right/Down = next, Home/End = first/last with wrap, Space/Enter select) that moves selection **and** DOM focus together. Compact is a native `<button>` with a descriptive `aria-label`/`title`.
- **Cross-tab / programmatic live updates:** new opt-in `ColorModePicker.syncAcrossTabs` subscribes to the `Broadcast` color-mode channel and re-highlights every mounted picker (addresses the OXY-154 "does not re-highlight on cross-tab changes" caveat). Off by default — no bootstrap behavior change.
- **Pure decision logic** extracted into `ColorModePicker.Logic` and **unit-tested** (6 new DOM-free tests).
- **Showcase:** `ThemePage` now demos the variants. **Docs:** `docs/docs/ui/builders.md` updated.

## Decoupling note
`ColorModePicker` never had a code-level dependency on `ThemePicker` (they only shared a *pattern*). Confirmed and kept its shared state seeded via `ColorMode.storageKey` / `ColorMode.parse` — no reference to `Theme` / `OxygenThemes` / `ThemePicker`.

A native `<select>`/dropdown "form" variant was intentionally **not** added: labeled form contexts are already served by the generic `HorizontalRadio.form[ColorMode.Mode]`.

## Verification
- `oxygen-ui-web/compile` ✅
- `example-ui-web/compile` ✅
- `oxygen-ui-web/test` ✅ (51 tests, incl. 6 new `ColorModePicker.Logic` tests)
- `sbt fmt` applied. No regressions to `ColorMode` / `Theme` / `ColorTheme` / `ThemePicker` or existing call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YxWKdsz97QT9BD7AdpSq6