### PR TITLE
OXY-165: Add LIKE / ILIKE predicate support to the oxygen-sql query DSL

### DIFF
--- a/docs/docs/sql/queries.md
+++ b/docs/docs/sql/queries.md
@@ -121,6 +121,7 @@ input makes it a `QueryO`/`Query`. Pass `debug = true` (`@compile(debug = true)`
 | `select[A]` | select all columns of table `A` |
 | `join[A] if <cond>` / `leftJoin[A] if <cond>` | inner / left join (`leftJoin` yields `Option[A]`) |
 | `where if <cond>` | filter |
+| `s.like(p)` / `s.ilike(p)` / `s.notLike(p)` / `s.notILike(p)` | string pattern match (see below) |
 | `orderBy(a.field.asc, …)`, `limit(n)`, `offset(n)` | ordering / paging |
 | `Q.insert[A]` / `Q.update[A]` / `Q.delete[A]` | begin an insert / update / delete |
 | `set(_.field := value)` | assignment in an update |
@@ -138,6 +139,31 @@ val personJoinNotes: QueryIO[UUID, (Person, Note)] =
     n <- join[Note] if n.personId == p.id
     _ <- where if p.groupId == i
   } yield (p, n)
+```
+
+### String pattern matching (`LIKE` / `ILIKE`)
+
+On `String` columns, four predicates map to SQL's pattern-matching operators. The pattern binds as a
+single scalar `String` parameter, so the generated SQL stays static (`col LIKE ?`):
+
+| Form | SQL | Notes |
+|------|-----|-------|
+| `col.like(pattern)` | `col LIKE ?` | case-sensitive |
+| `col.ilike(pattern)` | `col ILIKE ?` | case-insensitive (Postgres-specific) |
+| `col.notLike(pattern)` | `col NOT LIKE ?` | |
+| `col.notILike(pattern)` | `col NOT ILIKE ?` | case-insensitive (Postgres-specific) |
+
+The pattern uses the usual SQL wildcards: `%` matches any sequence of characters and `_` matches
+exactly one. Predicates compose with `&&` / `||` like any other condition.
+
+```scala
+@compile
+val searchByName: QueryIO[String, Person] =
+  for {
+    pattern <- input[String]
+    p       <- select[Person]
+    _       <- where if p.first.ilike(pattern)   // e.g. "al%" matches "Alice", "alfred", …
+  } yield p
 ```
 
 > Custom column types flow through automatically: `input[Email]` and `select[UserRow]` use the

--- a/modules/sql/core/src/main/scala/oxygen/sql/generic/model/BinOp.scala
+++ b/modules/sql/core/src/main/scala/oxygen/sql/generic/model/BinOp.scala
@@ -27,6 +27,10 @@ private[generic] object BinOp {
     case `<+>` extends Comp("<+>", "<+>")
     case `@>` extends Comp("@>", "@>")
     case `<@` extends Comp("<@", "<@")
+    case like extends Comp("LIKE", "like")
+    case ilike extends Comp("ILIKE", "ilike")
+    case notLike extends Comp("NOT LIKE", "notLike")
+    case notILike extends Comp("NOT ILIKE", "notILike")
 
     final def show: String = sql.hexFg("#E6C120").toString
 
@@ -40,7 +44,7 @@ private[generic] object BinOp {
 
   }
 
-  // TODO (KR) : combine: `+`. `-`, `*`, `/`, `like`
+  // TODO (KR) : combine: `+`. `-`, `*`, `/`
 
   val sql: StrictEnum[BinOp] = StrictEnum.derive[BinOp]((op: BinOp) => op.sql)
   val scala: StrictEnum[BinOp] = StrictEnum.derive[BinOp]((op: BinOp) => op.scala)

--- a/modules/sql/core/src/main/scala/oxygen/sql/query/dsl/Q.scala
+++ b/modules/sql/core/src/main/scala/oxygen/sql/query/dsl/Q.scala
@@ -70,6 +70,12 @@ object Q {
     def @>(value: A): Boolean = macroOnly // is ancestor of (ltree)
     def <@(value: A): Boolean = macroOnly // is descendant of (ltree)
 
+  extension (self: String)
+    def like(pattern: String): Boolean = macroOnly // SQL `LIKE` (case-sensitive pattern match)
+    def ilike(pattern: String): Boolean = macroOnly // SQL `ILIKE` (case-insensitive pattern match, Postgres-specific)
+    def notLike(pattern: String): Boolean = macroOnly // SQL `NOT LIKE`
+    def notILike(pattern: String): Boolean = macroOnly // SQL `NOT ILIKE` (Postgres-specific)
+
   def mkSqlString(strings: String*): String = macroOnly
 
 }

--- a/modules/sql/it-test/src/test/scala/oxygen/sql/CustomQuerySpec.scala
+++ b/modules/sql/it-test/src/test/scala/oxygen/sql/CustomQuerySpec.scala
@@ -341,6 +341,46 @@ object CustomQuerySpec extends OxygenSpec[Database] {
           res2 == Set(ab, abc1, abc2),
         )
       },
+      test("like / ilike") {
+        for {
+          groupId <- Random.nextUUID
+
+          // deterministic first names covering wildcard + case-sensitivity scenarios
+          alice <- Person.generate(groupId)(first = "Alice", age = 30)
+          alicia <- Person.generate(groupId)(first = "Alicia", age = 40)
+          alfred <- Person.generate(groupId)(first = "Alfred", age = 50)
+          bob <- Person.generate(groupId)(first = "Bob", age = 60)
+          aliceLower <- Person.generate(groupId)(first = "alice", age = 70)
+
+          _ <- Person.insert.all(alice, alicia, alfred, bob, aliceLower).unit
+
+          // `%` wildcard: everything starting with "Al" (case-sensitive) -> Alice, Alicia, Alfred
+          likePct <- queries.personFirstLike("Al%").to[Set]
+          // `_` wildcard: "Ali" + exactly two chars -> Alice, Alicia is 6 -> only "Alice" (Ali + ce)
+          likeUnderscore <- queries.personFirstLike("Ali__").to[Set]
+          // LIKE is case-sensitive: "alice" pattern matches only the lowercase row
+          likeCase <- queries.personFirstLike("alice").to[Set]
+          // ILIKE is case-insensitive: "alice" matches "Alice" and "alice"
+          ilikeCase <- queries.personFirstILike("alice").to[Set]
+          // ILIKE with `%`: "al%" case-insensitively -> all the Al-names + lowercase alice
+          ilikePct <- queries.personFirstILike("al%").to[Set]
+          // NOT LIKE: not starting with "Al" (case-sensitive) -> Bob + lowercase alice
+          notLike <- queries.personFirstNotLike("Al%").to[Set]
+          // NOT ILIKE: not starting with "al" case-insensitively -> only Bob
+          notILike <- queries.personFirstNotILike("al%").to[Set]
+          // composition with `&&`: starts with "Al" AND age >= 45 -> Alfred(50)
+          composed <- queries.personLikeAndMinAge.execute("Al%", 45).to[Set]
+        } yield assertTrue(
+          likePct == Set(alice, alicia, alfred),
+          likeUnderscore == Set(alice),
+          likeCase == Set(aliceLower),
+          ilikeCase == Set(alice, aliceLower),
+          ilikePct == Set(alice, alicia, alfred, aliceLower),
+          notLike == Set(bob, aliceLower),
+          notILike == Set(bob),
+          composed == Set(alfred),
+        )
+      },
     )
 
   override def testAspects: Chunk[CustomQuerySpec.TestSpecAspect] = Chunk(TestAspect.nondeterministic, TestAspect.withLiveClock, SqlAspects.isolateTestsInRollbackTransaction)

--- a/modules/sql/it-test/src/test/scala/oxygen/sql/queries.scala
+++ b/modules/sql/it-test/src/test/scala/oxygen/sql/queries.scala
@@ -395,6 +395,48 @@ object queries {
       _ <- where if n.tree <@ in
     } yield n
 
+  @compile
+  val personFirstLike: QueryIO[String, Person] =
+    for {
+      pattern <- input[String]
+      p <- select[Person]
+      _ <- where if p.first.like(pattern)
+    } yield p
+
+  @compile
+  val personFirstILike: QueryIO[String, Person] =
+    for {
+      pattern <- input[String]
+      p <- select[Person]
+      _ <- where if p.first.ilike(pattern)
+    } yield p
+
+  @compile
+  val personFirstNotLike: QueryIO[String, Person] =
+    for {
+      pattern <- input[String]
+      p <- select[Person]
+      _ <- where if p.first.notLike(pattern)
+    } yield p
+
+  @compile
+  val personFirstNotILike: QueryIO[String, Person] =
+    for {
+      pattern <- input[String]
+      p <- select[Person]
+      _ <- where if p.first.notILike(pattern)
+    } yield p
+
+  // LIKE composed with another predicate (`&&`)
+  @compile
+  val personLikeAndMinAge: QueryIO[(String, Int), Person] =
+    for {
+      pattern <- input[String]
+      minAge <- input[Int]
+      p <- select[Person]
+      _ <- where if p.first.like(pattern) && p.age >= minAge
+    } yield p
+
   //////////////////////////////////////////////////////////////////////////////////////////////////////
   //      Update
   //////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## OXY-165 — Add LIKE / ILIKE predicate support to the oxygen-sql query DSL

Adds `LIKE` / `ILIKE` (case-insensitive) string-pattern predicates — plus their negations — to the `@compile` query DSL, usable in `where if ...` on `String` columns. The pattern binds as a single scalar `String` param, so the generated SQL stays **static** (`col LIKE ?` / `col ILIKE ?`).

### How it fits
Per the OXY-163 roadmap, the DSL's binary-operator extension points are generic. These slot in purely as new `BinOp.Comp` cases — the rest of the pipeline (`RawQueryExpr`, `QueryExpr`, `FragmentBuilder`) is generic over `Comp`, so **no other production code changed**. The `query-var op input-var` path already emits `col <op> ?` and binds the input using the LHS column's `RowRepr`.

### DSL surface
On `String` columns:
- `col.like(pattern)` → `col LIKE ?`
- `col.ilike(pattern)` → `col ILIKE ?` (Postgres-specific)
- `col.notLike(pattern)` → `col NOT LIKE ?`
- `col.notILike(pattern)` → `col NOT ILIKE ?` (Postgres-specific)

### Changes
- `BinOp.scala`: 4 new `Comp` cases.
- `Q.scala`: `extension (self: String)` methods.
- `it-test/queries.scala`: 5 `@compile` queries.
- `it-test/CustomQuerySpec.scala`: `like / ilike` integration test.
- `docs/docs/sql/queries.md`: vocabulary row + dedicated section.

### Testing
- `oxygen-sql/compile` + `sql-it/Test/compile` succeed (the macro-expanded `@compile` queries compile, exercising the DSL + parser).
- `sql-it/testOnly oxygen.sql.CustomQuerySpec` against **real Postgres** (testcontainers): **13/13 pass**, including the new test covering `%`/`_` wildcards, LIKE vs ILIKE case-sensitivity, `NOT LIKE`/`NOT ILIKE`, and `&&` composition.
- `sbt fmt` applied.

### Notes
- `ILIKE` / `NOT ILIKE` are Postgres-specific — acceptable while oxygen-sql is PG-only; flagged for the future Dialect seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YxWKdsz97QT9BD7AdpSq6