### PR TITLE
OFF-325: Add compatibility checking to db migrations

### DIFF
--- a/modules/sql/it-test/src/test/scala/oxygen/sql/migration/MigrationGeneratorSpec.scala
+++ b/modules/sql/it-test/src/test/scala/oxygen/sql/migration/MigrationGeneratorSpec.scala
@@ -3,7 +3,7 @@ package oxygen.sql.migration
 import oxygen.core.Version
 import oxygen.predef.test.*
 import oxygen.sql.migration.MigrationGenerator.GenerateResult
-import oxygen.sql.migration.model.MigrationState
+import oxygen.sql.migration.model.*
 import oxygen.sql.migration.persistence.model.{MigrationCompatibility, MigrationStepColumn}
 import oxygen.sql.query.TableCompanion
 import oxygen.sql.schema.*
@@ -34,6 +34,18 @@ object MigrationGeneratorSpec extends OxygenSpecDefault {
     result match
       case Right(g: GenerateResult.Generated) => g
       case other                              => throw new RuntimeException(s"expected Generated, got: $other")
+
+  // Fixtures for exercising the classification table directly (pure -- no DB).
+  private val personTable: TableState = TableState.unsafeFromTable(PersonV1.tableRepr)
+  private val personRef: EntityRef.TableRef = personTable.tableName
+  private val otherRef: EntityRef.TableRef = EntityRef.TableRef("public", "other")
+
+  private def mkCol(name: String, nullable: Boolean): Column = Column(name, Column.Type.Int, nullable)
+  private def colRef(name: String): EntityRef.ColumnRef = EntityRef.ColumnRef(personRef, name)
+  private def fkOn(self: EntityRef.TableRef): ForeignKeyState = ForeignKeyState(None, self, otherRef, ArraySeq(ForeignKeyState.Pair("other_id", "id")))
+  private def idxOn(self: EntityRef.TableRef, unique: Boolean): IndexState = IndexState(None, self, unique, ArraySeq("name"))
+
+  private def classify(diffs: StateDiff*): MigrationCompatibility = MigrationGenerator.classify(ArraySeq.from(diffs))
 
   override def testSpec: TestSpec =
     suite("MigrationGeneratorSpec")(
@@ -70,6 +82,60 @@ object MigrationGeneratorSpec extends OxygenSpecDefault {
           g.file.previousVersion.contains("1.0.0"),
         )
       },
+      suite("classify (classification table)")(
+        test("empty diff -> BackwardsCompatible") {
+          assertTrue(classify() == MigrationCompatibility.BackwardsCompatible)
+        },
+        test("CreateColumn: nullable is compatible, NOT NULL is incompatible") {
+          assertTrue(
+            classify(StateDiff.AlterColumn.CreateColumn(personRef, mkCol("nickname", nullable = true))) == MigrationCompatibility.BackwardsCompatible,
+            classify(StateDiff.AlterColumn.CreateColumn(personRef, mkCol("age", nullable = false))) == MigrationCompatibility.Incompatible,
+          )
+        },
+        test("SetNullable: relaxing is compatible, tightening is incompatible") {
+          assertTrue(
+            classify(StateDiff.AlterColumn.SetNullable(colRef("name"), nullable = true)) == MigrationCompatibility.BackwardsCompatible,
+            classify(StateDiff.AlterColumn.SetNullable(colRef("name"), nullable = false)) == MigrationCompatibility.Incompatible,
+          )
+        },
+        test("drops: column/table/schema are incompatible; foreign-key/index are compatible") {
+          assertTrue(
+            classify(StateDiff.AlterColumn.DropColumn(colRef("name"))) == MigrationCompatibility.Incompatible,
+            classify(StateDiff.AlterTable.DropTable(personRef)) == MigrationCompatibility.Incompatible,
+            classify(StateDiff.AlterSchema.DropSchema(EntityRef.SchemaRef("public"))) == MigrationCompatibility.Incompatible,
+            classify(StateDiff.AlterForeignKey.DropForeignKey(fkOn(personRef).ref)) == MigrationCompatibility.BackwardsCompatible,
+            classify(StateDiff.AlterIndex.DropIndex(idxOn(personRef, unique = true).ref)) == MigrationCompatibility.BackwardsCompatible,
+          )
+        },
+        test("RenameColumn is incompatible") {
+          assertTrue(classify(StateDiff.AlterColumn.RenameColumn(colRef("name"), "full_name")) == MigrationCompatibility.Incompatible)
+        },
+        test("foreign key: incompatible on an existing table, compatible on a same-migration new table") {
+          assertTrue(
+            classify(StateDiff.AlterForeignKey.CreateForeignKey(fkOn(personRef))) == MigrationCompatibility.Incompatible,
+            classify(StateDiff.AlterTable.CreateTable(personTable), StateDiff.AlterForeignKey.CreateForeignKey(fkOn(personRef))) == MigrationCompatibility.BackwardsCompatible,
+          )
+        },
+        test("index: unique incompatible on existing table, compatible on new table; non-unique always compatible") {
+          assertTrue(
+            classify(StateDiff.AlterIndex.CreateIndex(idxOn(personRef, unique = true))) == MigrationCompatibility.Incompatible,
+            classify(StateDiff.AlterTable.CreateTable(personTable), StateDiff.AlterIndex.CreateIndex(idxOn(personRef, unique = true))) == MigrationCompatibility.BackwardsCompatible,
+            classify(StateDiff.AlterIndex.CreateIndex(idxOn(personRef, unique = false))) == MigrationCompatibility.BackwardsCompatible,
+          )
+        },
+        test("aggregate: any single incompatible diff makes the whole migration incompatible") {
+          assertTrue(
+            classify(
+              StateDiff.AlterColumn.CreateColumn(personRef, mkCol("nickname", nullable = true)),
+              StateDiff.AlterColumn.DropColumn(colRef("name")),
+            ) == MigrationCompatibility.Incompatible,
+            classify(
+              StateDiff.AlterColumn.CreateColumn(personRef, mkCol("nickname", nullable = true)),
+              StateDiff.AlterIndex.CreateIndex(idxOn(personRef, unique = false)),
+            ) == MigrationCompatibility.BackwardsCompatible,
+          )
+        },
+      ),
     )
 
 }


### PR DESCRIPTION
## What & why

OFF-325 asks for compatibility checking on db migrations (add / remove / alter columns → schema compatibility). Grounding found the feature is **already fully implemented and merged on `main`**: `MigrationGenerator.classify`/`bump`, the `MigrationCompatibility` enum, `MigrationCheck` with `OXYGEN_MIGRATION_ALLOW_UPDATE` / `OXYGEN_MIGRATION_ALLOW_INCOMPATIBLE` gating, and `PersistedMigrationFile.compatibility`. So the remaining work is **verification/closure**, not green-field.

## What changed

Adds verification-hardening unit tests to `MigrationGeneratorSpec` that drive `MigrationGenerator.classify` directly (pure, no DB) over hand-built `StateDiff`s, covering the classification-table branches the existing spec did not exercise:

- the same-migration **`createdTables` exception** — FK / unique index are `BackwardsCompatible` only on a table created in the same migration, else `Incompatible`;
- `SetNullable` relax (compatible) vs tighten (incompatible);
- `CreateColumn` nullable vs `NOT NULL`;
- drops: column/table/schema `Incompatible`, foreign-key/index `BackwardsCompatible`;
- `RenameColumn` incompatible; non-unique index always compatible;
- the aggregate rule: any single incompatible diff ⇒ the whole migration is `Incompatible`.

No production code is touched — this turns the "verify the classification table matches the intended contract" ask into executable assertions + a regression guard. No behavior change ⇒ no doc / migration-json edits.

**Deferred** (agent-proposed design decisions, left for a human call — not in scope for this 1-pt task): default-value-aware `NOT NULL` classification (`Column` has no default concept yet), apply-time gating in `MigrationService`, and a richer multi-level compat lattice.

## Verification

`sbt "scalafmtAll; sql-it/testOnly oxygen.sql.migration.MigrationGeneratorSpec"` → compiles clean, **12 passed / 0 failed** (4 original + 8 new).

Jira: OFF-325