### PR TITLE
OFF-320: Implement prepared statement caching

### DIFF
--- a/docs/docs/sql/database.md
+++ b/docs/docs/sql/database.md
@@ -53,11 +53,36 @@ entirely from the JSON.
 | `connectTimeout` | `connectTimeout` | `Duration`, sent as whole seconds. |
 | `socketTimeout` | `socketTimeout` | `Duration`, sent as whole seconds. |
 | `applicationName` | `ApplicationName` | Shows up in `pg_stat_activity`. |
+| `preparedStatementCache` | *(nested)* | pgjdbc server-side prepared-statement caching — see below. |
 | `extraProperties` | *(verbatim)* | `Map[String, String]` escape hatch for any other driver knob. |
 
 Property values are Postgres (`pgjdbc`) flavored. `extraProperties` are applied **last**, so they
 override the typed properties (and credentials) on a key collision — the escape hatch always wins.
 So `"ssl prefer"` from the ticket is simply `"connection": { "sslMode": "prefer" }`.
+
+#### Prepared-statement caching — `DbConfig.Connection.preparedStatementCache`
+
+pgjdbc keeps a **per-connection cache of server-prepared statements keyed by SQL text** (it survives
+the client-side `PreparedStatement.close()`), and promotes a statement to a server-prepared plan after
+it has been executed `prepareThreshold` times. Because oxygen-sql pools and reuses connections, this
+amortizes the Postgres `Parse` cost across executions of the same SQL. This block exposes the pgjdbc
+knobs in a typed way; **every field is optional and omitting the block is a no-op** that leaves
+pgjdbc's own defaults in force.
+
+| Field | JDBC property | pgjdbc default | Notes |
+|-------|---------------|----------------|-------|
+| `prepareThreshold` | `prepareThreshold` | `5` | Executions before a statement becomes server-prepared. `0` disables server-side prepared plans. |
+| `cacheQueries` | `preparedStatementCacheQueries` | `256` | Number of statements cached per connection. `0` disables client-side caching. |
+| `cacheSizeMiB` | `preparedStatementCacheSizeMiB` | `5` | Max cache size per connection, in MiB. `0` disables client-side caching. |
+
+```json
+"connection": {
+  "preparedStatementCache": { "prepareThreshold": 5, "cacheQueries": 256, "cacheSizeMiB": 5 }
+}
+```
+
+To turn client-side statement caching off entirely, set `"cacheQueries": 0` (and/or
+`"cacheSizeMiB": 0`).
 
 ## The Database layer
 

--- a/modules/sql/core/src/main/scala/oxygen/sql/DbConfig.scala
+++ b/modules/sql/core/src/main/scala/oxygen/sql/DbConfig.scala
@@ -45,6 +45,7 @@ object DbConfig {
     * @param connectTimeout Max time to establish the TCP connection (`connectTimeout`, whole seconds).
     * @param socketTimeout  Max time a socket read may block (`socketTimeout`, whole seconds).
     * @param applicationName Reported to the server as `ApplicationName` (shows up in `pg_stat_activity`).
+    * @param preparedStatementCache pgjdbc server-side prepared-statement caching knobs (see [[PreparedStatementCache]]).
     * @param extraProperties Escape hatch: arbitrary driver properties copied verbatim. Applied last, so these
     *                        override the typed properties (and credentials) on key collision.
     */
@@ -56,6 +57,7 @@ object DbConfig {
       connectTimeout: Option[Duration] = None,
       socketTimeout: Option[Duration] = None,
       applicationName: Option[String] = None,
+      preparedStatementCache: PreparedStatementCache = PreparedStatementCache.default,
       extraProperties: Map[String, String] = Map.empty,
   ) derives JsonSchema {
 
@@ -69,11 +71,45 @@ object DbConfig {
         connectTimeout.map(d => "connectTimeout" -> d.toSeconds.toString),
         socketTimeout.map(d => "socketTimeout" -> d.toSeconds.toString),
         applicationName.map("ApplicationName" -> _),
-      ).flatten ++ extraProperties.toSeq
+      ).flatten ++ preparedStatementCache.properties ++ extraProperties.toSeq
 
   }
   object Connection {
     val default: Connection = Connection()
+  }
+
+  /**
+    * pgjdbc **server-side prepared-statement caching** knobs. pgjdbc keeps a per-connection cache of server-prepared
+    * statements keyed by SQL text (surviving the client-side `PreparedStatement.close()`), and promotes a statement to
+    * a server-prepared plan after it has been executed `prepareThreshold` times — so on a pooled (reused) connection the
+    * Postgres `Parse` cost is amortized across executions of the same SQL.
+    *
+    * Every field is optional and defaults to "unset" ([[PreparedStatementCache.default]]), which leaves pgjdbc's own
+    * defaults in force (`prepareThreshold` 5, `preparedStatementCacheQueries` 256, `preparedStatementCacheSizeMiB` 5) —
+    * so omitting this block is a no-op that preserves existing behavior. Set a field to override; set the two cache
+    * fields to `0` to disable client-side caching entirely (`prepareThreshold` `0` disables server-side prepared plans).
+    *
+    * @param prepareThreshold pgjdbc `prepareThreshold` — executions of a statement before it becomes server-prepared.
+    * @param cacheQueries     pgjdbc `preparedStatementCacheQueries` — number of statements cached per connection (`0` disables).
+    * @param cacheSizeMiB     pgjdbc `preparedStatementCacheSizeMiB` — max cache size per connection, in MiB (`0` disables).
+    */
+  final case class PreparedStatementCache(
+      prepareThreshold: Option[Int] = None,
+      cacheQueries: Option[Int] = None,
+      cacheSizeMiB: Option[Int] = None,
+  ) derives JsonSchema {
+
+    /** Typed cache settings translated into pgjdbc `(key, value)` property pairs (empty when nothing is set). */
+    def properties: Seq[(String, String)] =
+      Seq(
+        prepareThreshold.map(v => "prepareThreshold" -> v.toString),
+        cacheQueries.map(v => "preparedStatementCacheQueries" -> v.toString),
+        cacheSizeMiB.map(v => "preparedStatementCacheSizeMiB" -> v.toString),
+      ).flatten
+
+  }
+  object PreparedStatementCache {
+    val default: PreparedStatementCache = PreparedStatementCache()
   }
 
   /**

--- a/modules/sql/core/src/test/scala/oxygen/sql/DbConfigSpec.scala
+++ b/modules/sql/core/src/test/scala/oxygen/sql/DbConfigSpec.scala
@@ -63,6 +63,79 @@ object DbConfigSpec extends OxygenSpecDefault {
       },
     )
 
+  private def preparedStatementCacheSpec: TestSpec =
+    suite("PreparedStatementCache")(
+      test("default emits no properties (leaves pgjdbc defaults in force)") {
+        assertTrue(DbConfig.PreparedStatementCache.default.properties.isEmpty)
+      },
+      test("populated settings translate to pgjdbc property pairs") {
+        val cache = DbConfig.PreparedStatementCache(
+          prepareThreshold = 3.some,
+          cacheQueries = 512.some,
+          cacheSizeMiB = 10.some,
+        )
+        assertTrue(
+          cache.properties.toMap == Map(
+            "prepareThreshold" -> "3",
+            "preparedStatementCacheQueries" -> "512",
+            "preparedStatementCacheSizeMiB" -> "10",
+          ),
+        )
+      },
+      test("zeros are emitted verbatim (disable caching)") {
+        val cache = DbConfig.PreparedStatementCache(cacheQueries = 0.some, cacheSizeMiB = 0.some)
+        assertTrue(
+          cache.properties.toMap == Map(
+            "preparedStatementCacheQueries" -> "0",
+            "preparedStatementCacheSizeMiB" -> "0",
+          ),
+        )
+      },
+      test("cache pairs surface in Connection.properties, before the extraProperties escape hatch") {
+        val conn = DbConfig.Connection(
+          preparedStatementCache = DbConfig.PreparedStatementCache(cacheQueries = 256.some),
+          extraProperties = Map("preparedStatementCacheQueries" -> "1"),
+        )
+        val collapsed: Map[String, String] = conn.properties.toMap
+        assertTrue(
+          // typed cache pair is present, and extraProperties (applied last) wins on collision
+          conn.properties.contains("preparedStatementCacheQueries" -> "256"),
+          collapsed("preparedStatementCacheQueries") == "1",
+        )
+      },
+      test("cache pairs are threaded through buildProperties") {
+        val conn = DbConfig.Connection(preparedStatementCache = DbConfig.PreparedStatementCache(prepareThreshold = 2.some))
+        val props = Driver.JdbcDriver.buildProperties(DbConfig.Credentials("u", "p").some, conn)
+        assertTrue(
+          propsToMap(props) == Map(
+            "user" -> "u",
+            "password" -> "p",
+            "prepareThreshold" -> "2",
+          ),
+        )
+      },
+      test("preparedStatementCache block decodes from JSON") {
+        val json =
+          """{
+            |  "preparedStatementCache": { "prepareThreshold": 3, "cacheQueries": 512, "cacheSizeMiB": 10 }
+            |}""".stripMargin
+        assertTrue(
+          JsonSchema[DbConfig.Connection].decode(json) == Right(
+            DbConfig.Connection(
+              preparedStatementCache = DbConfig.PreparedStatementCache(
+                prepareThreshold = 3.some,
+                cacheQueries = 512.some,
+                cacheSizeMiB = 10.some,
+              ),
+            ),
+          ),
+        )
+      },
+      test("omitting the block defaults to the empty cache") {
+        assertTrue(JsonSchema[DbConfig.Connection].decode("{}").map(_.preparedStatementCache) == Right(DbConfig.PreparedStatementCache.default))
+      },
+    )
+
   private def buildPropertiesSpec: TestSpec =
     suite("JdbcDriver.buildProperties")(
       test("only user/password when connection is unset (preserves historical behavior)") {
@@ -149,6 +222,7 @@ object DbConfigSpec extends OxygenSpecDefault {
     suite("DbConfigSpec")(
       sslModeSpec,
       propertiesSpec,
+      preparedStatementCacheSpec,
       buildPropertiesSpec,
       decodingSpec,
     )


### PR DESCRIPTION
Adds a typed, opt-in surface for pgjdbc **server-side prepared-statement caching** on `DbConfig.Connection`.

## What & why
pgjdbc already keeps a per-connection cache of server-prepared statements keyed by SQL text (it survives the client-side `PreparedStatement.close()`) and promotes a statement to a server-prepared plan after `prepareThreshold` executions. Because oxygen-sql pools and reuses connections, the Postgres `Parse` cost is already amortized at pgjdbc's defaults — what was missing is a **typed, documented way to tune or disable it**. This PR adds exactly that; it is not caching-from-scratch.

**Driver-level only.** No app-level per-connection LRU: it would duplicate pgjdbc's (transaction-safe) cache and drag in the `Scope`-cleanup and `Atomically` rollback/savepoint invalidation hazards the issue flags, for no benefit.

## Changes
- `DbConfig.PreparedStatementCache(prepareThreshold, cacheQueries, cacheSizeMiB: Option[Int])` — derives `JsonSchema`, `.properties` → `prepareThreshold` / `preparedStatementCacheQueries` / `preparedStatementCacheSizeMiB`.
- Nested `preparedStatementCache` field on `DbConfig.Connection`; its pairs are appended in `Connection.properties` **before** `extraProperties`, so the escape hatch still wins on collision. `Driver.buildProperties` funnels these unchanged.
- Every field is optional; **omitting the block is a no-op** that preserves pgjdbc defaults. Set the cache fields to `0` to disable client-side caching.
- Docs: `docs/docs/sql/database.md` gains a knob/property/default table + JSON example.
- Tests: `DbConfigSpec` gains a `PreparedStatementCache` suite — translation, disable-via-zero, `extraProperties` precedence, `buildProperties` threading, JSON decode. Full spec is green (18 tests).

## Open questions from the ticket, resolved
1. Driver-only (not app-level LRU). 2. Opt-in, preserving pgjdbc defaults. 3. Typed config (generic passthrough already exists as `extraProperties`). 4. N/A — pgjdbc keys internally. 5. N/A — pgjdbc manages server-statement lifecycle across tx/savepoint.

Jira: OFF-320