### PR TITLE
OFF-316: Add support to `Atomically` for `not in transaction -> wrap in transaction`, but `already in transaction -> I dont care about savepoint`

### DIFF
--- a/modules/sql/core/src/main/scala/oxygen/sql/Atomically.scala
+++ b/modules/sql/core/src/main/scala/oxygen/sql/Atomically.scala
@@ -8,6 +8,7 @@ type Atomically = oxygen.storage.Atomically
 object Atomically {
 
   val atomically: ZIOAspectAtLeastR[Atomically] = oxygen.storage.Atomically.atomically
+  val ensureAtomic: ZIOAspectAtLeastR[Atomically] = oxygen.storage.Atomically.ensureAtomic
 
   /**
     * TLDR : Transaction(commit/rollback) -> Savepoint(commit/rollback) -> Savepoint(commit/rollback) -> ...
@@ -34,6 +35,15 @@ object Atomically {
     override def atomically[R, E, A](effect: ZIO[R, E, A]): ZIO[R, E, A] =
       ZIO.scoped { atomicallyScoped *> effect }
 
+    override def ensureAtomicScoped: URIO[Scope, Unit] =
+      db.currentConnectionType.flatMap {
+        case Database.ConnectionState.ConnectionType.Transactionless  => atomicallyScoped
+        case _: Database.ConnectionState.ConnectionType.Transactional => ZIO.unit
+      }
+
+    override def ensureAtomic[R, E, A](effect: ZIO[R, E, A]): ZIO[R, E, A] =
+      ZIO.scoped { ensureAtomicScoped *> effect }
+
   }
   object LiveDB {
 
@@ -41,6 +51,12 @@ object Atomically {
       new ZIOAspectAtLeastR.Impl[Database] {
         override def apply[R <: Database, E, A](effect: ZIO[R, E, A])(using trace: Trace): ZIO[R, E, A] =
           (effect @@ Atomically.atomically).provideSomeLayer[R](LiveDB.layer)
+      }
+
+    val ensureAtomic: ZIOAspectAtLeastR[Database] =
+      new ZIOAspectAtLeastR.Impl[Database] {
+        override def apply[R <: Database, E, A](effect: ZIO[R, E, A])(using trace: Trace): ZIO[R, E, A] =
+          (effect @@ Atomically.ensureAtomic).provideSomeLayer[R](LiveDB.layer)
       }
 
     val layer: URLayer[Database, Atomically] =
@@ -74,6 +90,15 @@ object Atomically {
     override def atomically[R, E, A](effect: ZIO[R, E, A]): ZIO[R, E, A] =
       ZIO.scoped { atomicallyScoped *> effect }
 
+    override def ensureAtomicScoped: URIO[Scope, Unit] =
+      db.currentConnectionType.flatMap {
+        case Database.ConnectionState.ConnectionType.Transactionless  => atomicallyScoped
+        case _: Database.ConnectionState.ConnectionType.Transactional => ZIO.unit
+      }
+
+    override def ensureAtomic[R, E, A](effect: ZIO[R, E, A]): ZIO[R, E, A] =
+      ZIO.scoped { ensureAtomicScoped *> effect }
+
   }
   object RollbackDB {
 
@@ -81,6 +106,12 @@ object Atomically {
       new ZIOAspectAtLeastR.Impl[Database] {
         override def apply[R <: Database, E, A](effect: ZIO[R, E, A])(using trace: Trace): ZIO[R, E, A] =
           (effect @@ Atomically.atomically).provideSomeLayer[R](RollbackDB.layer)
+      }
+
+    val ensureAtomic: ZIOAspectAtLeastR[Database] =
+      new ZIOAspectAtLeastR.Impl[Database] {
+        override def apply[R <: Database, E, A](effect: ZIO[R, E, A])(using trace: Trace): ZIO[R, E, A] =
+          (effect @@ Atomically.ensureAtomic).provideSomeLayer[R](RollbackDB.layer)
       }
 
     val layer: URLayer[Database, Atomically] =

--- a/modules/sql/core/src/main/scala/oxygen/sql/Database.scala
+++ b/modules/sql/core/src/main/scala/oxygen/sql/Database.scala
@@ -26,6 +26,9 @@ final class Database(
   //           : Or maybe, keeping track of transaction/savepoints in the db state is not necessary.
   //           : This might be prevented by the mutex, but should be tested.
 
+  /** Peek the current connection type without allocating an atomic child (unlike [[getAtomicChild]], which always does). */
+  private[sql] def currentConnectionType: UIO[Database.ConnectionState.ConnectionType.Any] = connectionStateRef.get.map(_.connectionType)
+
   private[sql] def getConnection: ZIO[Scope, ConnectionError, Connection] = connectionStateRef.getWith(_.getConnection)
   private[sql] def getConnectionAndType: ZIO[Scope, ConnectionError, (Connection, Database.ConnectionState.ConnectionType.Any)] = connectionStateRef.getWith(_.getConnectionAndType)
 

--- a/modules/sql/it-test/src/test/scala/oxygen/sql/AtomicallySpec.scala
+++ b/modules/sql/it-test/src/test/scala/oxygen/sql/AtomicallySpec.scala
@@ -1,0 +1,55 @@
+package oxygen.sql
+
+import oxygen.predef.test.*
+import zio.*
+
+object AtomicallySpec extends OxygenSpec[Database] {
+
+  private val transactionless: Database.ConnectionState.ConnectionType.Any = Database.ConnectionState.ConnectionType.Transactionless
+  private val transaction: Database.ConnectionState.ConnectionType.Any = Database.ConnectionState.ConnectionType.Transaction
+
+  private val observeConnectionType: URIO[Database, Database.ConnectionState.ConnectionType.Any] =
+    ZIO.serviceWithZIO[Database](_.currentConnectionType)
+
+  private def isSavepoint(ct: Database.ConnectionState.ConnectionType.Any): Boolean =
+    ct match {
+      case _: Database.ConnectionState.ConnectionType.Savepoint => true
+      case _                                                    => false
+    }
+
+  override def testSpec: TestSpec =
+    suite("AtomicallySpec")(
+      test("baseline : outside any block, the connection is transactionless") {
+        for {
+          ct <- observeConnectionType
+        } yield assertTrue(ct == transactionless)
+      },
+      test("ensureAtomic outermost opens a real transaction") {
+        for {
+          ct <- observeConnectionType @@ Atomically.LiveDB.ensureAtomic
+        } yield assertTrue(ct == transaction)
+      },
+      test("ensureAtomic nested inside a transaction does NOT open a savepoint") {
+        for {
+          ct <- (observeConnectionType @@ Atomically.LiveDB.ensureAtomic) @@ Atomically.LiveDB.atomically
+        } yield assertTrue(ct == transaction)
+      },
+      test("ensureAtomic nested inside a savepoint stays that savepoint (still a no-op)") {
+        for {
+          ct <- ((observeConnectionType @@ Atomically.LiveDB.ensureAtomic) @@ Atomically.LiveDB.atomically) @@ Atomically.LiveDB.atomically
+        } yield assertTrue(isSavepoint(ct))
+      },
+      test("contrast : nested plain atomically DOES open a savepoint") {
+        for {
+          ct <- (observeConnectionType @@ Atomically.LiveDB.atomically) @@ Atomically.LiveDB.atomically
+        } yield assertTrue(isSavepoint(ct))
+      },
+    ) @@ TestAspect.sequential
+
+  override def layerProvider: LayerProvider[R] =
+    LayerProvider.provideShared[Env](
+      Helpers.testContainerLayer,
+      Helpers.databaseLayer,
+    )
+
+}

--- a/modules/sql/storage/src/main/scala/oxygen/storage/Atomically.scala
+++ b/modules/sql/storage/src/main/scala/oxygen/storage/Atomically.scala
@@ -8,6 +8,21 @@ trait Atomically extends ZIOAspectPoly.Impl {
   def atomicallyScoped: URIO[Scope, Unit]
   def atomically[R, E, A](effect: ZIO[R, E, A]): ZIO[R, E, A]
 
+  /**
+    * Weaker sibling of [[atomicallyScoped]] : ensures the surrounding effect runs inside *a* transaction,
+    * but does not add a nested savepoint when one is already open.
+    *
+    * When executed outside any other `atomically`/`ensureAtomic` block, this opens a real transaction
+    * (identical to [[atomicallyScoped]]'s outermost behavior).
+    *
+    * When executed while already inside a transaction or savepoint, this is a no-op : the effect runs
+    * inline, with no new savepoint and no extra `BEGIN`.
+    */
+  def ensureAtomicScoped: URIO[Scope, Unit]
+
+  /** Effect-wrapping form of [[ensureAtomicScoped]]. */
+  def ensureAtomic[R, E, A](effect: ZIO[R, E, A]): ZIO[R, E, A]
+
   override final def apply[R, E, A](effect: ZIO[R, E, A])(using trace: Trace): ZIO[R, E, A] = atomically(effect)
 
 }
@@ -19,9 +34,17 @@ object Atomically {
         ZIO.serviceWithZIO[Atomically](_.atomically(effect))
     }
 
+  val ensureAtomic: ZIOAspectAtLeastR[Atomically] =
+    new ZIOAspectAtLeastR.Impl[Atomically] {
+      override def apply[R <: Atomically, E, A](effect: ZIO[R, E, A])(using trace: Trace): ZIO[R, E, A] =
+        ZIO.serviceWithZIO[Atomically](_.ensureAtomic(effect))
+    }
+
   final class NoOp extends Atomically {
     override def atomicallyScoped: URIO[Scope, Unit] = ZIO.unit
     override def atomically[R, E, A](effect: ZIO[R, E, A]): ZIO[R, E, A] = effect
+    override def ensureAtomicScoped: URIO[Scope, Unit] = ZIO.unit
+    override def ensureAtomic[R, E, A](effect: ZIO[R, E, A]): ZIO[R, E, A] = effect
   }
   object NoOp {
 


### PR DESCRIPTION
Adds a weaker sibling of `atomically` to the `oxygen-sql` `Atomically` service: **ensure the effect runs inside *a* transaction, but if we're already inside one, don't bother with a nested savepoint — just run it inline.**

- Not in a transaction -> wrap in a transaction (identical to the current outermost `atomically` behavior).
- Already in a transaction/savepoint -> **no-op wrapper**: run the effect directly (no new savepoint, no extra `BEGIN`).

### Changes
- **`oxygen.storage.Atomically`** (trait) — new `ensureAtomicScoped: URIO[Scope, Unit]` + `ensureAtomic[R, E, A]` members (scaladoc'd), a companion `ensureAtomic` `ZIOAspectAtLeastR[Atomically]` aspect mirroring `atomically`, and the trivial `NoOp` pass-through.
- **`oxygen.sql.Database`** — `private[sql] currentConnectionType` that peeks the current `ConnectionState.connectionType` **without** allocating an atomic child (`getAtomicChild` always does).
- **`oxygen.sql.Atomically`** — implemented `ensureAtomicScoped` in both `LiveDB` and `RollbackDB` (branch on the current connection type: `Transactionless` -> delegate to the existing `atomicallyScoped`; already `Transactional` -> `ZIO.unit`), re-exported `ensureAtomic`, and added object-level `ensureAtomic` aspect vals on `LiveDB`/`RollbackDB`. The existing `atomically` methods are untouched (no regression surface).
- **`sql-it`** — new `AtomicallySpec` proving the semantics via the connection-type peek: outermost `ensureAtomic` opens a transaction; nested-in-transaction stays a transaction (NO savepoint); nested-in-savepoint stays that savepoint; and a contrast that nested plain `atomically` DOES open a savepoint.

### Resolved open questions (from the ticket)
- **Naming/shape:** `ensureAtomic` — both a trait method and an aspect val (mirrors `atomically`).
- **Scope:** applies to **both** `LiveDB` and `RollbackDB`.
- **"Already in a transaction":** treats **both** `Transaction` and `Savepoint` as already-transactional.
- **Refactor vs separate:** existing `atomically` kept fully separate; the new path only *delegates* to the shared `atomicallyScoped`.

### Verification
`oxygen-storage` / `oxygen-sql` / `sql-it` compile clean; scalafmt applied; `AtomicallySpec` — 5/5 pass.

Jira: OFF-316

🤖 Generated with [Claude Code](https://claude.com/claude-code)