### PR TITLE
OFF-426: Fix long text in page message not wrapping

### DIFF
--- a/example/apps/ui/src/main/scala/oxygen/example/ui/page/showcase/pages/MessagesPage.scala
+++ b/example/apps/ui/src/main/scala/oxygen/example/ui/page/showcase/pages/MessagesPage.scala
@@ -8,7 +8,11 @@ import oxygen.ui.web.create.{*, given}
 object MessagesPage extends ShowcaseLayout.SimplePage {
   override val path: Seq[String] = Seq("showcase", "feedback", "messages")
   override def pageTitle: String = "Page messages"
-  override def body: Widget =
+  override def body: Widget = {
+    // An unbroken run (no break opportunities) is the only case that actually exercises
+    // `word-break: break-word` / `overflow-wrap: anywhere` on the toast text container; the
+    // `"…, " * 50` repros below have a space/comma every few chars and soft-wrap without them.
+    val unbrokenRun: String = "https://oxygen.example.com/very/long/path?token=" + ("a1b2c3d4e5" * 24)
     fragment(
       ShowcaseLayout.note("Fire toasts via PageMessages (bottom corner mounted in layout)."),
       div(
@@ -30,5 +34,13 @@ object MessagesPage extends ShowcaseLayout.SimplePage {
         span(display.inlineBlock, width := S.spacing._2),
         Button("Error").small.negative.content(onClick := PageMessages.add(PageMessage.error("Failed, " * 50))),
       ),
+      Spacing.vertical._6,
+      ShowcaseLayout.note("Unbroken run (no spaces / long URL): verifies overflow-wrap: anywhere + word-break on the text container."),
+      div(
+        Button("Info").small.informational.content(onClick := PageMessages.add(PageMessage.info(unbrokenRun))),
+        span(display.inlineBlock, width := S.spacing._2),
+        Button("Error").small.negative.content(onClick := PageMessages.add(PageMessage.error(unbrokenRun))),
+      ),
     )
+  }
 }


### PR DESCRIPTION
## Change

**Adds an unbroken-string repro row to the page-message showcase** (`MessagesPage`).

Grounding finding: the actual wrapping fix is **already on `main`** — it landed via `1f225732`
("The big oxygen-ui refactor"), **not** the `369bb2f0` savepoint the triage cited (that commit is
on `save/ui-overhaul`, not an ancestor of `main`). `PageMessagesBottomCorner` on `main` already:
pre-wraps (`white-space: pre-wrap`), breaks long words / unbroken runs (`word-break: break-word` +
`overflow-wrap: anywhere`), uses a flex-row card (`flex-shrink: 0`, `max-width: 100%`,
`overflow: hidden`) with a flex dismiss button (`aria-label`), and a positioning-only shell
(`pointer-events: none`) whose inner list owns scroll via `O.Scrollable`, viewport-capped at
`min(maxWidth, 100vw-24px)` / `min(maxHeight, 100dvh-96px)`. So no component change is warranted —
fabricating one would be redundant.

The one genuine gap was in **verification**: the existing `MessagesPage` repros only fired
space-separated strings (`"..., " * 50`), which soft-wrap without ever exercising
`word-break` / `overflow-wrap: anywhere`. This PR adds a third row firing a ~288-char **unbroken**
URL (Info + Error) so that behavior is actually demonstrable — resolving triage open-question #2
(unbroken-string policy).

Component untouched; reuses existing Oxygen `Button` / `PageMessages.add` idioms.

## Verify

- `sbt "; example-ui-web/scalafmt ; example-ui-web/compile"` → green (compiles `oxygen-ui-web` + example modules for Scala.js).
- Visual: open the showcase Page-messages page, click the new unbroken-URL toasts; the card caps at max-width and the URL wraps/breaks inside it.

Jira: OFF-426
