### PR TITLE
OFF-317: Add inline configurability to query timeouts

### DIFF
--- a/modules/sql/core/src/main/scala/oxygen/sql/Database.scala
+++ b/modules/sql/core/src/main/scala/oxygen/sql/Database.scala
@@ -9,7 +9,7 @@ import zio.*
 import zio.stream.*
 
 final class Database(
-    private val executionConfig: DbConfig.Execution,
+    private val executionConfigRef: FiberRef[DbConfig.Execution],
     private val logConfigRef: FiberRef[DbConfig.Logging],
     connectionStateRef: FiberRef[Database.ConnectionState],
 ) {
@@ -46,9 +46,10 @@ object Database {
       driver <- Driver.makePSQL
       connect = driver.getConnection(config.target, config.credentials, config.connection)
       pool <- ConnectionPool.makeZPool(connect, config.pool)
+      executionConfigRef <- FiberRef.make(config.execution)
       logConfigRef <- FiberRef.make(config.logging)
       connectionStateRef <- FiberRef.make[ConnectionState](ConnectionState.Pool(pool))
-    } yield Database(config.execution, logConfigRef, connectionStateRef)
+    } yield Database(executionConfigRef, logConfigRef, connectionStateRef)
 
   val baseLayer: URLayer[ConnectionPool & DbConfig.Logging & DbConfig.Execution, Database] =
     ZLayer.scoped {
@@ -56,9 +57,10 @@ object Database {
         pool <- ZIO.service[ConnectionPool]
         logConfig <- ZIO.service[DbConfig.Logging]
         executionConfig <- ZIO.service[DbConfig.Execution]
+        executionConfigRef <- FiberRef.make(executionConfig)
         logConfigRef <- FiberRef.make(logConfig)
         connectionStateRef <- FiberRef.make[ConnectionState](ConnectionState.Pool(pool))
-      } yield Database(executionConfig, logConfigRef, connectionStateRef)
+      } yield Database(executionConfigRef, logConfigRef, connectionStateRef)
     }
 
   val layer: URLayer[DbConfig, Database] =
@@ -86,7 +88,7 @@ object Database {
       }
 
   private[sql] val executionConfig: URIO[Database, DbConfig.Execution] =
-    ZIO.serviceWith[Database](_.executionConfig)
+    ZIO.serviceWithZIO[Database](_.executionConfigRef.get)
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////
   //      Connection State
@@ -171,6 +173,30 @@ object Database {
 
     override def apply[R <: Database, E, A](effect: ZIO[R, E, A])(using trace: Trace): ZIO[R, E, A] =
       ZIO.serviceWithZIO[Database](_.logConfigRef.locallyWith(f)(effect))
+
+  }
+
+  private final class ModifyExecutionConfig(f: DbConfig.Execution => DbConfig.Execution) extends ZIOAspectAtLeastR.Impl[Database] {
+
+    override def apply[R <: Database, E, A](effect: ZIO[R, E, A])(using trace: Trace): ZIO[R, E, A] =
+      ZIO.serviceWithZIO[Database](_.executionConfigRef.locallyWith(f)(effect))
+
+  }
+
+  /**
+    * Overrides the query timeout for the wrapped effect only, modeled on [[withQueryLogLevel]].
+    * The override is fiber-local (via [[DbConfig.Execution.queryTimeout]] behind a `FiberRef`), so it
+    * applies to every query executed within the effect and is restored afterwards.
+    *
+    * {{{
+    *   longRunningDbMigrationEffect @@ Database.withQueryTimeout(1.hour)
+    * }}}
+    */
+  object withQueryTimeout {
+
+    def apply(timeout: Duration): ZIOAspectAtLeastR[Database] = ModifyExecutionConfig(_.copy(queryTimeout = Some(timeout)))
+
+    val none: ZIOAspectAtLeastR[Database] = ModifyExecutionConfig(_.copy(queryTimeout = None))
 
   }
 

--- a/modules/sql/core/src/main/scala/oxygen/sql/DbConfig.scala
+++ b/modules/sql/core/src/main/scala/oxygen/sql/DbConfig.scala
@@ -115,10 +115,12 @@ object DbConfig {
   /**
     * @param bufferChunkSize Size of the chunk to read from JDBC result set
     * @param bufferNumChunks Optional buffering of chunks.
+    * @param queryTimeout Optional per-query timeout. [[None]] means no timeout (the default). Applied via JDBC `setQueryTimeout`, so it is rounded up to whole seconds. Can be overridden for a single effect via [[Database.withQueryTimeout]].
     */
   final case class Execution(
       bufferChunkSize: NonEmptyList[Int] = NonEmptyList.of(16, 64, 64, 256, 256, 2048),
       bufferNumChunks: Option[Int] = 2.some,
+      queryTimeout: Option[Duration] = None,
   ) derives JsonSchema
   object Execution {
     val default: Execution = Execution()

--- a/modules/sql/core/src/main/scala/oxygen/sql/query/PreparedStatement.scala
+++ b/modules/sql/core/src/main/scala/oxygen/sql/query/PreparedStatement.scala
@@ -213,6 +213,19 @@ object PreparedStatement {
           }
         }
         .mapError(QueryError.JDBCError("setting fetch size", _))
+
+      exeCfg <- Database.executionConfig
+      _ <- ZIO
+        .foreachDiscard(queryTimeoutSeconds(exeCfg.queryTimeout)) { seconds => ZIO.attempt { rawPS.setQueryTimeout(seconds) } }
+        .mapError(QueryError.JDBCError("setting query timeout", _))
     } yield ps).uninterruptible.mapError(QueryError(ctx, _))
+
+  /**
+    * JDBC `setQueryTimeout` takes whole seconds, where `0` means "no timeout". Convert a [[Duration]] by
+    * rounding UP to the next whole second so that a sub-second timeout never silently becomes `0` (= no
+    * limit). A non-positive duration yields [[None]] (leaving the JDBC default of no timeout in place).
+    */
+  private def queryTimeoutSeconds(timeout: Option[Duration]): Option[Int] =
+    timeout.collect { case d if d.toNanos > 0L => math.min(Int.MaxValue.toLong, (d.toNanos + 999999999L) / 1000000000L).toInt }
 
 }

--- a/modules/sql/it-test/src/test/scala/oxygen/sql/QueryTimeoutSpec.scala
+++ b/modules/sql/it-test/src/test/scala/oxygen/sql/QueryTimeoutSpec.scala
@@ -1,0 +1,40 @@
+package oxygen.sql
+
+import oxygen.predef.test.*
+import oxygen.sql.query.{QueryContext, QueryO}
+import oxygen.sql.schema.RowRepr
+import zio.*
+
+object QueryTimeoutSpec extends OxygenSpec[Database] {
+
+  // `pg_sleep(n)` blocks for `n` seconds server-side; `::text` makes its `void` result decodable.
+  private def sleep(seconds: Int): ZIO[Database, Throwable, String] =
+    QueryO
+      .simple[String]("PgSleep", QueryContext.QueryType.Select)(RowRepr.string.decoder)(s"SELECT pg_sleep($seconds)::text")
+      .execute()
+      .single
+
+  override def testSpec: TestSpec =
+    suite("QueryTimeoutSpec")(
+      test("queryTimeout defaults to None") {
+        assertTrue(DbConfig.Execution.default.queryTimeout.isEmpty)
+      },
+      test("withQueryTimeout aborts a query that exceeds the timeout") {
+        for {
+          exit <- (sleep(30) @@ Database.withQueryTimeout(1.second)).exit
+        } yield assertTrue(exit.isFailure)
+      },
+      test("a query that completes within the timeout succeeds") {
+        for {
+          res <- sleep(1) @@ Database.withQueryTimeout(30.seconds)
+        } yield assertTrue(res == "")
+      },
+    ) @@ TestAspect.withLiveClock @@ TestAspect.timeout(1.minute) @@ TestAspect.sequential
+
+  override def layerProvider: LayerProvider[R] =
+    LayerProvider.provideShared[Env](
+      Helpers.testContainerLayer,
+      Helpers.databaseLayer,
+    )
+
+}


### PR DESCRIPTION
Adds a per-effect query-timeout override, modeled on the existing `Database.withQueryLogLevel` / `ModifyLogConfig` aspect.

## Changes
- **`DbConfig.Execution`** gains `queryTimeout: Option[Duration] = None` (`None` = no timeout — current behavior, explicit).
- **`Database`**: `executionConfig` promoted from a plain `val` to a `FiberRef[DbConfig.Execution]`, so it can be overridden fiber-locally (symmetry with `logConfigRef`). `make`, `baseLayer`, and the `executionConfig` accessor updated.
- **`Database.withQueryTimeout(duration)`** (+ `.none`) — a `ZIOAspectAtLeastR[Database]` via a private `ModifyExecutionConfig`, an exact mirror of `withQueryLogLevel`:
  ```scala
  longRunningDbMigrationEffect @@ Database.withQueryTimeout(1.hour)
  ```
- **`PreparedStatement.prepare`** applies the timeout via JDBC `setQueryTimeout`, rounding the `Duration` **up** to whole seconds so a sub-second timeout never collapses to `0` (= no limit); non-positive → left unset. Per-statement, so no reset finalizer needed.
- **it-test `QueryTimeoutSpec`** — default is `None`; `pg_sleep(30) @@ withQueryTimeout(1.second)` aborts; `pg_sleep(1) @@ withQueryTimeout(30.seconds)` succeeds.

## Verification
- `oxygen-sql/compile` + `sql-it/Test/compile` green.
- `QueryTimeoutSpec` — 3/3 pass against a real Postgres container.
- scalafmt clean.

Chose JDBC `setQueryTimeout` over `SET LOCAL statement_timeout` because it needs no surrounding transaction (migrations aren't always inside `Atomically`). A generic `settingsUpdate(...)` wrapper and ms-precision `SET LOCAL` remain possible follow-ups.

Jira: OFF-317