### PR TITLE
OFF-328: Add `on conflict` support to query dsl

### DIFF
--- a/docs/docs/sql/queries.md
+++ b/docs/docs/sql/queries.md
@@ -127,6 +127,7 @@ input makes it a `QueryO`/`Query`. Pass `debug = true` (`@compile(debug = true)`
 | `col.in(coll)` / `col.notIn(coll)` | `col = ANY(?)` / `col <> ALL(?)` over a runtime `Seq` / `Set` (static SQL, one array bind) |
 | `orderBy(a.field.asc, …)`, `limit(n)`, `offset(n)` | ordering / paging |
 | `Q.insert[A]` / `Q.update[A]` / `Q.delete[A]` | begin an insert / update / delete |
+| `into(v).onConflictDoNothing` / `into(v).onConflictDoUpdate` | `ON CONFLICT (pk) DO NOTHING` / `DO UPDATE …` on an insert (see below) |
 | `set(_.field := value)` | assignment in an update |
 | `count.*` / `count(a.field)` | `COUNT` aggregate (result `Long`, never null) |
 | `sum(a.field)` / `sum.orNull(a.field)` / `avg(a.field)` / `min(a.field)` / `max(a.field)` | scalar aggregate |
@@ -211,6 +212,39 @@ val searchByName: QueryIO[String, Person] =
 
 > Custom column types flow through automatically: `input[Email]` and `select[UserRow]` use the
 > `RowRepr`/encoder/decoder for `Email` you defined in [Models](models.md).
+
+### `ON CONFLICT` (upsert)
+
+A hand-written insert (`Q.insert[A]` or `Q.insert.fromSelect[A]`) can be made idempotent by chaining
+an `ON CONFLICT` clause onto the `into(…)` value. The conflict target is the table's **primary key**:
+
+| Form | SQL | Behavior on a PK collision |
+|------|-----|----------------------------|
+| `into(v).onConflictDoNothing` | `ON CONFLICT (pk) DO NOTHING` | keep the existing row |
+| `into(v).onConflictDoUpdate` | `ON CONFLICT (pk) DO UPDATE SET <non-pk> = EXCLUDED.<non-pk>` | overwrite every non-PK column from the incoming row |
+
+```scala
+@compile
+val upsertPerson: QueryI[Person] =
+  for {
+    p         <- input[Person]
+    (_, into) <- Q.insert[Person]
+    _         <- into(p).onConflictDoUpdate   // INSERT … ON CONFLICT (id) DO UPDATE SET group_id = EXCLUDED.group_id, …
+  } yield ()
+```
+
+Notes:
+
+- The target is always the PK (matching the generated `upsert` / `insertOrDoNothing`). Explicit
+  non-PK conflict targets, `ON CONSTRAINT`, partial-index `WHERE`, and custom `DO UPDATE SET … WHERE`
+  are not supported yet.
+- `onConflictDoUpdate` falls back to `DO NOTHING` when the table has no non-PK columns (a bare
+  `DO UPDATE SET` with no assignments is invalid SQL).
+- Works on both `Q.insert[A]` and `Q.insert.fromSelect[A]`, and composes with `batchOptimizedInsert`
+  (the `ON CONFLICT …` suffix rides along after `VALUES`).
+- For the common whole-row cases the generated CRUD `upsert` / `insertOrDoNothing` (see
+  [Generated CRUD](#generated-crud)) are simpler — reach for the DSL form when the insert itself is
+  hand-written (custom columns, `fromSelect`, …).
 
 ### Array input (`= ANY(?)`)
 

--- a/modules/sql/core/src/main/scala/oxygen/sql/generic/generation/FragmentBuilder.scala
+++ b/modules/sql/core/src/main/scala/oxygen/sql/generic/generation/FragmentBuilder.scala
@@ -541,6 +541,34 @@ final case class FragmentBuilder(inputs: List[InputPart])(using Quotes) {
       valuesFrag,
     )
 
+  /**
+    * `ON CONFLICT (pk...) DO NOTHING | DO UPDATE SET <non-pk> = EXCLUDED.<non-pk>`.
+    * The conflict target is the table's primary-key columns, and `DO UPDATE` sets every non-pk column
+    * to its `EXCLUDED` value -- falling back to `DO NOTHING` when there are no non-pk columns (a bare
+    * `DO UPDATE SET` with no assignments is not valid SQL). The column names are resolved from the
+    * table's `TableRepr` at runtime, mirroring the string built by `TableCompanion.upsert`.
+    */
+  def onConflict(oc: OnConflictPart, tableRepr: TypeclassExpr.TableRepr)(using Quotes): ParseResult[GeneratedFragment] = {
+    val sqlExpr: Expr[String] =
+      oc match {
+        case OnConflictPart.DoNothing =>
+          '{
+            val pkNames: ArraySeq[String] = ${ tableRepr.expr }.pk.rowRepr.columns.columns.map(_.name)
+            "\n    ON CONFLICT (" + pkNames.mkString(", ") + ")\n    DO NOTHING"
+          }
+        case OnConflictPart.DoUpdate =>
+          '{
+            val pkNames: ArraySeq[String] = ${ tableRepr.expr }.pk.rowRepr.columns.columns.map(_.name)
+            val npkNames: ArraySeq[String] = ${ tableRepr.expr }.npk.rowRepr.columns.columns.map(_.name)
+            val target: String = "\n    ON CONFLICT (" + pkNames.mkString(", ") + ")"
+            if npkNames.isEmpty then target + "\n    DO NOTHING"
+            else target + "\n    DO UPDATE\n    SET " + npkNames.map { n => n + " = EXCLUDED." + n }.mkString(",\n        ")
+          }
+      }
+
+    ParseResult.success(GeneratedFragment.sql(sqlExpr))
+  }
+
   private def setPart(s: SetPart.SetExpr)(using ParseContext, GenerationContext, Quotes): ParseResult[GeneratedFragment] = {
     val setTargetRowRepr: TypeclassExpr.RowRepr = s.fieldToSetExpr.rowRepr
     val setTargetColumnNames: Expr[ArraySeq[String]] = setTargetRowRepr.columns.exprSeqNames

--- a/modules/sql/core/src/main/scala/oxygen/sql/generic/model/ParsedQuery.scala
+++ b/modules/sql/core/src/main/scala/oxygen/sql/generic/model/ParsedQuery.scala
@@ -69,6 +69,7 @@ private[sql] object ParsedQuery extends Parser[Term, ParsedQuery] {
           fragmentBuilder = FragmentBuilder(inputs)
           insertFrag <- fragmentBuilder.insert(insert)
           valuesFrag <- fragmentBuilder.values(insert, into)
+          onConflictFrag <- into.onConflict.traverse(fragmentBuilder.onConflict(_, insert.tableRepr)).map(GeneratedFragment.option)
           returningFrag <- fragmentBuilder.ret(ret, "              ")
           frag = GeneratedFragment.of(
             insertFrag,
@@ -76,6 +77,7 @@ private[sql] object ParsedQuery extends Parser[Term, ParsedQuery] {
             '{ ${ insert.tableRepr.expr }.rowRepr.columns.`a, b, c` },
             ")",
             valuesFrag,
+            onConflictFrag,
             GeneratedFragment.option(
               returningFrag.map { ret =>
                 GeneratedFragment.of(
@@ -102,6 +104,7 @@ private[sql] object ParsedQuery extends Parser[Term, ParsedQuery] {
         inputs: List[InputPart],
         insert: InsertPart.FromSelect,
         select: ParsedQuery.SelectQuery,
+        onConflict: Option[OnConflictPart],
         ret: ReturningPart,
         refs: RefMap,
     ) extends InsertQuery {
@@ -127,6 +130,7 @@ private[sql] object ParsedQuery extends Parser[Term, ParsedQuery] {
           fragmentBuilder = FragmentBuilder(inputs)
           insertFrag <- fragmentBuilder.insert(insert)
           selectFrag <- select.makeFragment
+          onConflictFrag <- onConflict.traverse(fragmentBuilder.onConflict(_, insert.tableRepr)).map(GeneratedFragment.option)
           returningFrag <- fragmentBuilder.ret(ret, "              ")
           frag = GeneratedFragment.of(
             insertFrag,
@@ -134,6 +138,7 @@ private[sql] object ParsedQuery extends Parser[Term, ParsedQuery] {
             '{ ${ insert.tableRepr.expr }.rowRepr.columns.`a, b, c` },
             ")\n",
             selectFrag,
+            onConflictFrag,
             GeneratedFragment.option(
               returningFrag.map { ret =>
                 GeneratedFragment.of(
@@ -384,7 +389,7 @@ private[sql] object ParsedQuery extends Parser[Term, ParsedQuery] {
           ParsedQuery.InsertQuery.Basic(inputs, insert, into, ret, refs)
         case FullQueryResult(inputs, PartialQuery.InsertQuery.FromSelect(insert, s, into), ret, refs) =>
           val fullSelect = ParsedQuery.SelectQuery(inputs, s.select, s.joins, s.where, s.orderBy, s.limit, s.offset, into.toReturning, refs)
-          ParsedQuery.InsertQuery.FromSelect(inputs, insert, fullSelect, ret, refs)
+          ParsedQuery.InsertQuery.FromSelect(inputs, insert, fullSelect, into.onConflict, ret, refs)
         case FullQueryResult(inputs, PartialQuery.SelectQuery(select, joins, where, orderBy, limit, offset), ret, refs) =>
           ParsedQuery.SelectQuery(inputs, select, joins, where, orderBy, limit, offset, ret, refs)
         case FullQueryResult(inputs, PartialQuery.UpdateQuery(update, joins, where, set), ret, refs) =>

--- a/modules/sql/core/src/main/scala/oxygen/sql/generic/model/part/IntoPart.scala
+++ b/modules/sql/core/src/main/scala/oxygen/sql/generic/model/part/IntoPart.scala
@@ -8,10 +8,12 @@ import scala.quoted.*
 
 final case class IntoPart(
     queryExpr: QueryExpr,
+    onConflict: Option[OnConflictPart],
 )
 object IntoPart extends MapChainParser[IntoPart] {
 
   final case class FromSelect(into: IntoPart) {
+    def onConflict: Option[OnConflictPart] = into.onConflict
     def toReturning: ReturningPart = ReturningPart(into.queryExpr.fullTerm, ReturningPart.Elem(into.queryExpr, None) :: Nil)
   }
   object FromSelect extends MapChainParser.Deferred[FromSelect] {
@@ -26,12 +28,18 @@ object IntoPart extends MapChainParser[IntoPart] {
       mapAAFC <- AppliedAnonFunctCall.parseTyped[T.InsertValues](term, "map function").ignore
       _ <- mapAAFC.funct.parseEmptyParams
       mapFunctName <- functionNames.mapOrFlatMap.parse(mapAAFC.nameRef).unknownAsError
-      (_, argTerm) <- mapAAFC.lhs match { // TODO (KR) : validate `intoIdent`
+      // peel an optional `.onConflictDoNothing` / `.onConflictDoUpdate` suffix off the `into(...)` call
+      (intoTerm, onConflict) = mapAAFC.lhs match {
+        case Select(inner, "onConflictDoNothing") => (inner, Option(OnConflictPart.DoNothing))
+        case Select(inner, "onConflictDoUpdate")  => (inner, Option(OnConflictPart.DoUpdate))
+        case other                                => (other, None)
+      }
+      (_, argTerm) <- intoTerm match { // TODO (KR) : validate `intoIdent`
         case Apply(Select(intoIdent: Ident, "apply"), argTerm :: Nil) => ParseResult.Success((intoIdent, argTerm))
         case _                                                        => ParseResult.error(mapAAFC.lhs, "does not look like `into(...)`")
       }
       valueQueryExpr <- RawQueryExpr.parse((argTerm, refs)).unknownAsError
       valueQueryExpr <- QueryExpr.parse(valueQueryExpr).unknownAsError
-    } yield MapChainResult(IntoPart(valueQueryExpr), mapFunctName, refs, mapAAFC.appliedFunctionBody)
+    } yield MapChainResult(IntoPart(valueQueryExpr, onConflict), mapFunctName, refs, mapAAFC.appliedFunctionBody)
 
 }

--- a/modules/sql/core/src/main/scala/oxygen/sql/generic/model/part/OnConflictPart.scala
+++ b/modules/sql/core/src/main/scala/oxygen/sql/generic/model/part/OnConflictPart.scala
@@ -1,0 +1,12 @@
+package oxygen.sql.generic.model.part
+
+/**
+  * The `ON CONFLICT` clause of an insert, targeting the table's primary-key columns.
+  *   - [[DoNothing]] -> `ON CONFLICT (pk...) DO NOTHING`
+  *   - [[DoUpdate]]  -> `ON CONFLICT (pk...) DO UPDATE SET <non-pk> = EXCLUDED.<non-pk>`
+  *     (falls back to `DO NOTHING` when there are no non-primary-key columns).
+  */
+enum OnConflictPart {
+  case DoNothing
+  case DoUpdate
+}

--- a/modules/sql/core/src/main/scala/oxygen/sql/query/dsl/T.scala
+++ b/modules/sql/core/src/main/scala/oxygen/sql/query/dsl/T.scala
@@ -129,6 +129,15 @@ object T {
     def map[B](f: Unit => B): Ret[B] = macroOnly
     def flatMap[B](f: Unit => Ret[B]): Ret[B] = macroOnly
 
+    /** `ON CONFLICT (pk...) DO NOTHING` -- skip rows that collide on the primary key. */
+    def onConflictDoNothing: InsertValues = macroOnly
+
+    /**
+      * `ON CONFLICT (pk...) DO UPDATE SET <non-pk> = EXCLUDED.<non-pk>` -- upsert on the primary key.
+      * Falls back to `DO NOTHING` when the table has no non-primary-key columns.
+      */
+    def onConflictDoUpdate: InsertValues = macroOnly
+
   }
 
   final class UpdateSet private {

--- a/modules/sql/it-test/src/test/scala/oxygen/sql/CustomQuerySpec.scala
+++ b/modules/sql/it-test/src/test/scala/oxygen/sql/CustomQuerySpec.scala
@@ -362,6 +362,38 @@ object CustomQuerySpec extends OxygenSpec[Database] {
           ),
         )
       },
+      test("on conflict (DO NOTHING / DO UPDATE)") {
+        for {
+          groupId <- Random.nextUUID
+          id <- Random.nextUUID
+          p1 <- Person.generate(groupId)(id = id, age = 10)
+          p2 = p1.copy(age = 20)
+          p3 = p1.copy(age = 30)
+
+          // first insert lands the row
+          _ <- queries.insertPersonOnConflictDoNothing(p1).unit
+          afterInsert <- Person.selectByPK(id).single
+
+          // same PK -> DO NOTHING keeps the original row (age stays 10)
+          _ <- queries.insertPersonOnConflictDoNothing(p2).unit
+          afterDoNothing <- Person.selectByPK(id).single
+
+          // same PK -> DO UPDATE overwrites the non-pk columns from EXCLUDED (age -> 30)
+          _ <- queries.insertPersonOnConflictDoUpdate(p3).unit
+          afterDoUpdate <- Person.selectByPK(id).single
+        } yield assertTrue(
+          afterInsert == p1,
+          afterDoNothing == p1,
+          afterDoUpdate == p3,
+          // generated SQL shape
+          queries.insertPersonOnConflictDoNothing.ctx.sql.contains("ON CONFLICT (id)"),
+          queries.insertPersonOnConflictDoNothing.ctx.sql.contains("DO NOTHING"),
+          queries.insertPersonOnConflictDoUpdate.ctx.sql.contains("ON CONFLICT (id)"),
+          queries.insertPersonOnConflictDoUpdate.ctx.sql.contains("DO UPDATE"),
+          queries.insertPersonOnConflictDoUpdate.ctx.sql.contains("age = EXCLUDED.age"),
+          queries.insertNoteForPeopleOnConflictDoNothing.ctx.sql.contains("ON CONFLICT (id)"),
+        )
+      },
       test("insert from select 2") {
         for {
           groupId <- Random.nextUUID

--- a/modules/sql/it-test/src/test/scala/oxygen/sql/queries.scala
+++ b/modules/sql/it-test/src/test/scala/oxygen/sql/queries.scala
@@ -217,6 +217,38 @@ object queries {
       )
     } yield ()
 
+  // OFF-328: `ON CONFLICT` (upsert) support in the hand-written DSL, targeting the primary key.
+
+  @compile
+  val insertPersonOnConflictDoNothing: QueryI[Person] =
+    for {
+      i <- input[Person]
+      (_, into) <- Q.insert[Person]
+      _ <- into(i).onConflictDoNothing
+    } yield ()
+
+  @compile
+  val insertPersonOnConflictDoUpdate: QueryI[Person] =
+    for {
+      i <- input[Person]
+      (_, into) <- Q.insert[Person]
+      _ <- into(i).onConflictDoUpdate
+    } yield ()
+
+  @compile
+  val insertNoteForPeopleOnConflictDoNothing: Query =
+    for {
+      (_, into) <- Q.insert.fromSelect[Note]
+      p <- Q.select[Person]
+      _ <- into(
+        Note(
+          UUID.randomUUID(),
+          p.id,
+          mkSqlString(Q.const("Adding note for person "), p.first, " ", p.last, " : everyone"),
+        ),
+      ).onConflictDoNothing
+    } yield ()
+
   //////////////////////////////////////////////////////////////////////////////////////////////////////
   //      Select
   //////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Adds `ON CONFLICT` (upsert) support to the hand-written query DSL, targeting the table's primary key — closing the gap where `ON CONFLICT` was only available in the generated CRUD layer.

## What

- `into(v).onConflictDoNothing` → `ON CONFLICT (pk) DO NOTHING`
- `into(v).onConflictDoUpdate` → `ON CONFLICT (pk) DO UPDATE SET <non-pk> = EXCLUDED.<non-pk>` (falls back to `DO NOTHING` when the table has no non-PK columns)
- Works on both `Q.insert[A]` and `Q.insert.fromSelect[A]`.

## How

- New `OnConflictPart` model, parsed as an optional suffix on the `into(...)` generator in `IntoPart`.
- Threaded through `ParsedQuery.InsertQuery.{Basic,FromSelect}`; emitted by a new `FragmentBuilder.onConflict` (column names resolved from the `TableRepr` at runtime, matching `TableCompanion.upsert`).
- Batch path is unaffected — the `ON CONFLICT …` suffix lands after `VALUES` (as `batchOptimizedUpsert` already relies on).

## Scope

PK-targeted forms only. Explicit non-PK conflict targets, `ON CONSTRAINT`, partial-index `WHERE`, and custom `DO UPDATE SET … WHERE` are deferred as follow-ups.

## Tests

- Compile-time `@compile` snapshots in `queries.scala` (the macro gate).
- Postgres integration test in `CustomQuerySpec` (DO NOTHING keeps the row, DO UPDATE overwrites) + generated-SQL shape assertions — passing locally against a real container.
- Docs: `docs/docs/sql/queries.md`.

Jira: OFF-328