### PR TITLE
OFF-427: Weird mobile top bar issue (when url is shown/hidden)

### DIFF
--- a/modules/ui/web/src/main/scala/oxygen/ui/web/component/Drawer.scala
+++ b/modules/ui/web/src/main/scala/oxygen/ui/web/component/Drawer.scala
@@ -31,7 +31,7 @@ object Drawer {
           top := 0,
           left := 0,
           width := 100.vw,
-          height := 100.vh,
+          height := 100.dvh, // OFF-427: track the visible viewport on mobile (URL-bar show/hide)
           zIndex := ZIndices.modalBehindPageMessages,
           backgroundColor := S.color.bg.transparent,
           // dim backdrop via pseudo not available — use nested full-size dark layer

--- a/modules/ui/web/src/main/scala/oxygen/ui/web/create/OxygenStyleSheet.scala
+++ b/modules/ui/web/src/main/scala/oxygen/ui/web/create/OxygenStyleSheet.scala
@@ -273,7 +273,10 @@ object OxygenStyleSheet extends StyleSheetBuilder {
       top := 0,
       left := 0,
       width := 100.vw,
+      // OFF-427: 100vh → 100dvh fallback pair (stylesheet selectors keep duplicate keys); tracks the
+      // visible viewport as the mobile URL bar shows/hides, with a vh fallback for older browsers.
       height := 100.vh,
+      height := 100.dvh,
       display.flex,
       justifyContent.center,
       alignItems.center,

--- a/modules/ui/web/src/main/scala/oxygen/ui/web/create/extensions.scala
+++ b/modules/ui/web/src/main/scala/oxygen/ui/web/create/extensions.scala
@@ -11,6 +11,7 @@ extension (self: Int)
   def ch: String = s"${self}ch"
   def vw: String = s"${self}vw"
   def vh: String = s"${self}vh"
+  def dvh: String = s"${self}dvh"
 
 extension (self: Double)
   def pct: String = s"$self%"

--- a/modules/ui/web/src/main/scala/oxygen/ui/web/defaults/coreOxygenStyleSheets.scala
+++ b/modules/ui/web/src/main/scala/oxygen/ui/web/defaults/coreOxygenStyleSheets.scala
@@ -25,6 +25,7 @@ val coreOxygenStyleSheets: ArraySeq[StyleSheet] =
       InlinePseudoClassStyles.compiled,
       OxygenStyleSheet.compiled,
       ColumnsStyle.sheet,
+      HolyGrail.baseSheet,
       HolyGrail.responsiveSheet,
       Motion.sheet,
       Tooltip.sheet,

--- a/modules/ui/web/src/main/scala/oxygen/ui/web/layout/CenteredCard.scala
+++ b/modules/ui/web/src/main/scala/oxygen/ui/web/layout/CenteredCard.scala
@@ -53,7 +53,7 @@ final case class CenteredCard[-Env, +Action, -StateGet, +StateSet <: StateGet](
       justifyContent.center,
       alignItems.center,
       backgroundColorAttr := _pageBg,
-      minHeight := 100.vh,
+      minHeight := 100.dvh, // OFF-427: track the visible viewport on mobile (URL-bar show/hide)
       widthAttr := 100.pct,
       div(
         backgroundColorAttr := _cardBg,

--- a/modules/ui/web/src/main/scala/oxygen/ui/web/layout/HolyGrail.scala
+++ b/modules/ui/web/src/main/scala/oxygen/ui/web/layout/HolyGrail.scala
@@ -43,7 +43,8 @@ final case class HolyGrail[-Env, +Action, -StateGet, +StateSet <: StateGet](
           Widget.`class`("oxy-holy-grail"),
           //
           display.grid,
-          height := 100.vh,
+          // height comes from `baseSheet` (100vh → 100dvh fallback pair); kept out of the inline
+          // style so the below-md `responsiveSheet` rule can win on mobile (OFF-427).
           width := 100.vw,
           minHeight := 0,
           minWidth := 0,
@@ -66,7 +67,7 @@ final case class HolyGrail[-Env, +Action, -StateGet, +StateSet <: StateGet](
       else
         div(
           Widget.`class`("oxy-holy-grail", "oxy-holy-grail--center-only"),
-          height := 100.vh,
+          // height from `baseSheet` (see grid shell above) — OFF-427.
           width := 100.vw,
           minHeight := 0,
           minWidth := 0,
@@ -301,6 +302,27 @@ object HolyGrail extends WidgetTypes[HolyGrail] {
   def apply(): HolyGrail.Const = empty
 
   /**
+    * OFF-427: base height for the shell, kept out of the inline style so the below-`md`
+    * [[responsiveSheet]] rule can win on mobile (an inline style beats any non-`!important`
+    * stylesheet rule).
+    *
+    * The `100vh` → `100dvh` pair is a CSS fallback: modern browsers take the later, valid `100dvh`
+    * (tracks the *visible* viewport as the mobile URL bar shows/hides — the bug); older browsers that
+    * don't understand `dvh` drop it and fall back to `100vh`.
+    *
+    * MUST be registered *before* [[responsiveSheet]] in [[oxygen.ui.web.defaults.coreOxygenStyleSheets]]
+    * — equal specificity, media queries add none, so source order decides who wins below `md`.
+    */
+  val baseSheet: StyleSheet =
+    StyleSheet.makeConst("holy-grail-base")(
+      """.oxy-holy-grail {
+        |  height: 100vh;
+        |  height: 100dvh;
+        |}
+        |""".stripMargin,
+    )
+
+  /**
     * W5-T04: below `md`, hide left/right sidebars and force a single-column shell
     * so fixed desktop grids don't blow up mobile. Drawer/hamburger = Round 2 / TopBar todo.
     *
@@ -318,8 +340,8 @@ object HolyGrail extends WidgetTypes[HolyGrail] {
           |    "center"
           |    "bottom-bar" !important;
           |  height: auto;
-          |  min-height: 100dvh;
           |  min-height: 100vh;
+          |  min-height: 100dvh;
           |  width: 100%;
           |}
           |.oxy-holy-grail-left,


### PR DESCRIPTION
## Problem

On mobile the browser URL bar shows/hides as you scroll, changing the **visible** viewport height. The CSS `vh` unit always resolves to the **large** viewport (URL bar hidden), so any `height: 100vh` element is taller than what's actually visible while the URL bar is showing.

The `HolyGrail` shell used an inline `height: 100vh`. An inline style beats a non-`!important` stylesheet rule, so it overrode `HolyGrail.responsiveSheet`'s below-`md` `height: auto` / `min-height: 100dvh` — the shell got sized to the large viewport and the top grid row (the top bar) was pushed partly off-screen and appeared to jump as the URL bar toggled. (Jira OFF-427.)

## Fix

- **`.dvh` helper** added next to `.vh` in `create/extensions.scala`.
- **`HolyGrail`**: removed both inline `height: 100vh` (grid + center-only shells) and moved the height into a new `HolyGrail.baseSheet` that emits a `height: 100vh; height: 100dvh;` **fallback pair** (modern browsers take the valid `dvh`; older ones fall back to `vh`). Registered in `coreOxygenStyleSheets` **before** `responsiveSheet` so the below-`md` mobile rule still wins. This removes the inline-vs-stylesheet fight entirely.
- **Bonus defect fixed**: `responsiveSheet`'s `min-height` fallback pair was written in the wrong order (`100dvh` then `100vh`), which made modern browsers resolve `min-height` to `100vh`. Flipped to `100vh` then `100dvh`.
- **Audit of other full-viewport `100vh` consumers**:
  - `OxygenStyleSheet` `ModalOverlay` (a stylesheet selector) → emits the `100vh → 100dvh` pair.
  - `Drawer` + `CenteredCard` (inline) → `100.dvh` (bare — inline styles are a single value per property, so no pair is possible; this matches the existing house-style inline `dvh` in `PageMessagesBottomCorner`/`Modal`).
  - The ticket also named `OxygenStyleSheet:391` (a Dropdown "Scrim"); that line does not exist on `main` (only on the `pr-301` branch the ticket was drafted against), so it's out of scope here.

Why the shell uses a stylesheet fallback pair while `Drawer`/`CenteredCard` use bare inline `dvh`: inline CSS in this DSL is a `Map[String, String]` (one value per property), so a fallback pair is only possible in `selector(...)` stylesheet blocks. The shell — the highest-value element and the one the ticket calls out for a fallback — is worth moving to a sheet; the secondary inline consumers follow existing house style.

## Verification

- `oxygen-ui-web/compile` — green.
- `oxygen-ui-web/scalafmt` — clean.
- No tests reference these literals.

## ⚠️ Residual uncertainty

The fix is derived from the CSS + UI-DSL mechanics (confirmed against the source), **but I could not verify it on a real mobile device** in this environment. Worth a quick manual check on a phone that:
1. the top bar no longer clips/jumps as the URL bar shows/hides, and
2. center-scroll containment still behaves (the ticket left this as an open question).

I kept `dvh` (not `svh`) per the ticket's default; `dvh` re-layouts on every URL-bar transition, a known accepted trade-off.

Jira: OFF-427
