### PR TITLE
OFF-341: Add compatibility spec for DB Schema

### DIFF
--- a/docs/docs/sql/migrations.md
+++ b/docs/docs/sql/migrations.md
@@ -77,6 +77,38 @@ created in the *same* migration stay compatible, since the table is empty.
 > **No default values yet.** A non-nullable column add is always classified incompatible, because a
 > `NOT NULL` column with no default breaks existing rows. Default-value support is planned.
 
+### Rich per-column diagnostics
+
+The generator's classification is a single flag. When you want to know *what* is incompatible — not
+just *that* something is — use the pure comparison spec directly:
+
+```scala
+import oxygen.sql.migration.compat.DbCompatibilitySpec
+
+val result = DbCompatibilitySpec.compare(fromState, toState)   // two MigrationStates
+result.compatibility   // MigrationCompatibility — the same verdict the generator uses
+result.isCompatible    // Boolean
+println(result.pruned.toIndentedString.toString)   // only the actual differences
+```
+
+`compare` diffs extensions, schemas, and every table (added / removed / changed), and within a
+changed table its columns, primary key, foreign keys, and indices. The result is the DB analogue of
+the HTTP-schema `oxygen.schema.compat` lattice — it reuses that package's `FromToValues` /
+`AddedRemovedBoth` and collapses to the same binary `MigrationCompatibility` the harness consumes, so
+the rich diagnostics never disagree with the coarse gate.
+
+On top of the generator's rules it also classifies **column-type changes**, which the flag ignores:
+
+| Type transition | Verdict |
+|-----------------|---------|
+| Same type | compatible |
+| Lossless widening: `SMALLINT → INT → BIGINT`, `REAL → DOUBLE PRECISION` | compatible |
+| The reverse of a widening (a narrowing) | incompatible |
+| `T[] → U[]` | delegates to `T → U` |
+| Any other cross-type change | incompatible (fail-closed) |
+
+It is spec-only and database-free — a diagnostic lens over two schema states, not a new gate.
+
 ## Applying at runtime
 
 `MigrationService` reads the committed files and applies any the database hasn't run. Point it at

--- a/modules/sql/migration/src/main/scala/oxygen/sql/migration/compat/DbComparisonResult.scala
+++ b/modules/sql/migration/src/main/scala/oxygen/sql/migration/compat/DbComparisonResult.scala
@@ -1,0 +1,163 @@
+package oxygen.sql.migration.compat
+
+import oxygen.predef.core.*
+import oxygen.schema.compat.{AddedRemovedBoth, FromToValues}
+import oxygen.sql.migration.model.*
+import oxygen.sql.migration.model.EntityRef.*
+import oxygen.sql.migration.persistence.model.MigrationCompatibility
+import oxygen.sql.schema.Column
+
+/**
+  * The structural diff of two [[MigrationState]]s (`from` -> `to`), the DB analogue of
+  * `oxygen.schema.compat.ComparisonResult`. It reuses that package's generic `FromToValues` /
+  * `AddedRemovedBoth` lattice, layers on DB-specific compatibility rules, and collapses to the
+  * binary [[MigrationCompatibility]] the migration harness already understands -- while retaining
+  * per-column diagnostics via [[toIndentedString]].
+  *
+  * The rules agree with `MigrationGenerator.classifyOne` everywhere they overlap; the one addition
+  * is per-column type widening/narrowing (which the coarse gate does not model). The empty-table
+  * exception falls out structurally: constraints on a freshly-`added` table sit in the added bucket
+  * (compatible), and only constraints on a table present in `both` states face the strict rules.
+  */
+final case class DbComparisonResult(
+    extensions: AddedRemovedBoth.Many[String, String],
+    schemas: AddedRemovedBoth.Many[SchemaRef, SchemaRef],
+    tables: AddedRemovedBoth.Many[TableState, DbComparisonResult.TableComparison],
+) {
+
+  import DbComparisonResult.worst
+
+  lazy val compatibility: MigrationCompatibility =
+    worst(
+      Seq(
+        extensions.added.map(_ => MigrationCompatibility.BackwardsCompatible), // CREATE EXTENSION
+        extensions.removed.map(_ => MigrationCompatibility.BackwardsCompatible), // dropping an extension is not itself data-breaking
+        schemas.added.map(_ => MigrationCompatibility.BackwardsCompatible), // CREATE SCHEMA
+        schemas.removed.map(_ => MigrationCompatibility.Incompatible), // DROP SCHEMA
+        tables.added.map(_ => MigrationCompatibility.BackwardsCompatible), // CREATE TABLE
+        tables.removed.map(_ => MigrationCompatibility.Incompatible), // DROP TABLE
+        tables.both.map(_.compatibility),
+      ).flatten,
+    )
+
+  def isCompatible: Boolean = compatibility == MigrationCompatibility.BackwardsCompatible
+
+  def isDifferent: Boolean =
+    extensions.added.nonEmpty || extensions.removed.nonEmpty ||
+      schemas.added.nonEmpty || schemas.removed.nonEmpty ||
+      tables.added.nonEmpty || tables.removed.nonEmpty || tables.both.exists(_.isDifferent)
+
+  /** Collapse away the unchanged `both` entries, leaving only the actual differences. */
+  def pruned: DbComparisonResult =
+    DbComparisonResult(
+      extensions = extensions.prune(_ => None),
+      schemas = schemas.prune(_ => None),
+      tables = tables.prune(tc => Option.when(tc.isDifferent)(tc.pruned)),
+    )
+
+  def toIndentedString: IndentedString =
+    IndentedString.section("DbComparisonResult:")(
+      s"compatibility: ${MigrationCompatibility.show(compatibility)}",
+      IndentedString.section("extensions:")(extensions.toIndentedString(e => s"- $e", e => s"- $e")),
+      IndentedString.section("schemas:")(schemas.toIndentedString(s => s"- ${s.schemaName}", s => s"- ${s.schemaName}")),
+      IndentedString.section("tables:")(tables.toIndentedString(t => s"- ${t.tableName}", _.toIndentedString)),
+    )
+
+}
+object DbComparisonResult {
+
+  /** Backwards-compatible unless ANY component is incompatible (mirrors `MigrationGenerator.classify`). */
+  private[compat] def worst(cs: Seq[MigrationCompatibility]): MigrationCompatibility =
+    if cs.contains(MigrationCompatibility.Incompatible) then MigrationCompatibility.Incompatible
+    else MigrationCompatibility.BackwardsCompatible
+
+  /** Diff of a single table present in BOTH states (an existing, potentially non-empty table). */
+  final case class TableComparison(
+      tableRef: TableRef,
+      columns: AddedRemovedBoth.Many[Column, ColumnComparison],
+      primaryKey: FromToValues[Set[String]],
+      foreignKeys: AddedRemovedBoth.Many[ForeignKeyState, ConstraintComparison[ForeignKeyState]],
+      indices: AddedRemovedBoth.Many[IndexState, ConstraintComparison[IndexState]],
+  ) {
+
+    lazy val compatibility: MigrationCompatibility =
+      worst(
+        Seq(
+          columns.added.map(c => if c.nullable then MigrationCompatibility.BackwardsCompatible else MigrationCompatibility.Incompatible), // add nullable ok / non-nullable breaks
+          columns.removed.map(_ => MigrationCompatibility.Incompatible), // DROP COLUMN
+          columns.both.map(_.compatibility),
+          Seq(if primaryKey.isDifferent then MigrationCompatibility.Incompatible else MigrationCompatibility.BackwardsCompatible), // PK change on existing table
+          foreignKeys.added.map(_ => MigrationCompatibility.Incompatible), // add FK to existing table
+          foreignKeys.removed.map(_ => MigrationCompatibility.BackwardsCompatible),
+          foreignKeys.both.map(_.compatibility),
+          indices.added.map(i => if i.unique then MigrationCompatibility.Incompatible else MigrationCompatibility.BackwardsCompatible), // add unique index to existing table
+          indices.removed.map(_ => MigrationCompatibility.BackwardsCompatible),
+          indices.both.map(_.compatibility),
+        ).flatten,
+      )
+
+    def isDifferent: Boolean =
+      columns.added.nonEmpty || columns.removed.nonEmpty || columns.both.exists(_.isDifferent) ||
+        primaryKey.isDifferent ||
+        foreignKeys.added.nonEmpty || foreignKeys.removed.nonEmpty || foreignKeys.both.exists(_.isDifferent) ||
+        indices.added.nonEmpty || indices.removed.nonEmpty || indices.both.exists(_.isDifferent)
+
+    def pruned: TableComparison =
+      copy(
+        columns = columns.prune(c => Option.when(c.isDifferent)(c)),
+        foreignKeys = foreignKeys.prune(fk => Option.when(fk.isDifferent)(fk)),
+        indices = indices.prune(ix => Option.when(ix.isDifferent)(ix)),
+      )
+
+    def toIndentedString: IndentedString =
+      IndentedString.section(s"table($tableRef):")(
+        IndentedString.keyValue("primary-key: ", primaryKey.toIndentedString(pk => pk.toSeq.sorted.mkString("(", ", ", ")"))),
+        IndentedString.section("columns:")(columns.toIndentedString(c => s"- ${c.toSql}", _.toIndentedString)),
+        IndentedString.section("foreign-keys:")(foreignKeys.toIndentedString(fk => s"- ${fk.ref}", _.toIndentedString)),
+        IndentedString.section("indices:")(indices.toIndentedString(ix => s"- ${ix.ref}", _.toIndentedString)),
+      )
+
+  }
+
+  /** Diff of a single column present in BOTH tables. */
+  final case class ColumnComparison(
+      name: String,
+      nullable: FromToValues[Boolean],
+      columnType: TypeComparison,
+  ) {
+
+    lazy val compatibility: MigrationCompatibility = {
+      val nullableCompatibility: MigrationCompatibility = nullable match
+        case FromToValues.Same(_)                => MigrationCompatibility.BackwardsCompatible
+        case FromToValues.Different(false, true) => MigrationCompatibility.BackwardsCompatible // relax to NULL
+        case FromToValues.Different(_, _)        => MigrationCompatibility.Incompatible // tighten to NOT NULL
+      worst(Seq(nullableCompatibility, columnType.compatibility))
+    }
+
+    def isDifferent: Boolean = nullable.isDifferent || columnType.isDifferent
+
+    def toIndentedString: IndentedString =
+      IndentedString.keyValueSection(s"$name:")(
+        "nullable: " -> nullable.toIndentedString(_.toString),
+        "type: " -> columnType.toIndentedString,
+      )
+
+  }
+
+  /**
+    * Diff of a named constraint (FK / index) present in BOTH tables. A changed definition under the
+    * same name is a drop-and-recreate on an existing table -- treated as incompatible.
+    */
+  final case class ConstraintComparison[A: Show](ref: EntityRef, value: FromToValues[A]) {
+
+    def compatibility: MigrationCompatibility =
+      if value.isDifferent then MigrationCompatibility.Incompatible else MigrationCompatibility.BackwardsCompatible
+
+    def isDifferent: Boolean = value.isDifferent
+
+    def toIndentedString: IndentedString =
+      IndentedString.keyValueSection(s"$ref:")("value: " -> value.toIndentedString(_.show))
+
+  }
+
+}

--- a/modules/sql/migration/src/main/scala/oxygen/sql/migration/compat/DbCompatibilitySpec.scala
+++ b/modules/sql/migration/src/main/scala/oxygen/sql/migration/compat/DbCompatibilitySpec.scala
@@ -1,0 +1,54 @@
+package oxygen.sql.migration.compat
+
+import oxygen.schema.compat.{AddedRemovedBoth, FromToValues}
+import oxygen.sql.migration.compat.DbComparisonResult.*
+import oxygen.sql.migration.model.*
+import oxygen.sql.schema.Column
+
+/**
+  * Pure, DB-free compatibility spec for the migration schema. `compare(from, to)` produces a rich,
+  * per-entity [[DbComparisonResult]] whose `.compatibility` collapses to the binary
+  * `MigrationCompatibility` the migration harness consumes. See [[DbComparisonResult]] for the rule
+  * rationale (it agrees with `MigrationGenerator.classifyOne` where they overlap, and adds
+  * per-column type widening/narrowing on top).
+  */
+object DbCompatibilitySpec {
+
+  def compare(from: MigrationState, to: MigrationState): DbComparisonResult =
+    DbComparisonResult(
+      extensions = AddedRemovedBoth.Many.simpleSortedSet(from.extensions, to.extensions),
+      schemas = AddedRemovedBoth.Many.simpleSortedSet(from.schemas, to.schemas),
+      tables = diffMap(from.tables, to.tables)(compareTable),
+    )
+
+  private def compareTable(from: TableState, to: TableState): TableComparison =
+    TableComparison(
+      tableRef = to.tableName,
+      columns = diffSeq(from.columns, to.columns)(_.name)(compareColumn),
+      primaryKey = FromToValues(from.pkColNames, to.pkColNames),
+      foreignKeys = diffSeq(from.foreignKeys, to.foreignKeys)(_.fkName)((f, t) => ConstraintComparison(t.ref, FromToValues(f, t))),
+      indices = diffSeq(from.indices, to.indices)(_.idxName)((f, t) => ConstraintComparison(t.ref, FromToValues(f, t))),
+    )
+
+  private def compareColumn(from: Column, to: Column): ColumnComparison =
+    ColumnComparison(
+      name = to.name,
+      nullable = FromToValues(from.nullable, to.nullable),
+      columnType = TypeComparison.compare(from.columnType, to.columnType),
+    )
+
+  private def diffSeq[K: Ordering, V, B](from: Seq[V], to: Seq[V])(key: V => K)(both: (V, V) => B): AddedRemovedBoth.Many[V, B] =
+    diffMap(from.map(v => key(v) -> v).toMap, to.map(v => key(v) -> v).toMap)(both)
+
+  private def diffMap[K: Ordering, V, B](from: Map[K, V], to: Map[K, V])(both: (V, V) => B): AddedRemovedBoth.Many[V, B] = {
+    val addedKeys = (to.keySet -- from.keySet).toSeq.sorted
+    val removedKeys = (from.keySet -- to.keySet).toSeq.sorted
+    val bothKeys = (from.keySet & to.keySet).toSeq.sorted
+    AddedRemovedBoth.Many(
+      added = addedKeys.map(to(_)),
+      removed = removedKeys.map(from(_)),
+      both = bothKeys.map(k => both(from(k), to(k))),
+    )
+  }
+
+}

--- a/modules/sql/migration/src/main/scala/oxygen/sql/migration/compat/TypeComparison.scala
+++ b/modules/sql/migration/src/main/scala/oxygen/sql/migration/compat/TypeComparison.scala
@@ -1,0 +1,67 @@
+package oxygen.sql.migration.compat
+
+import oxygen.predef.core.*
+import oxygen.sql.migration.persistence.model.MigrationCompatibility
+import oxygen.sql.schema.Column
+
+/**
+  * Compatibility verdict for a single column-type transition `from -> to`.
+  *
+  * The verdict is intentionally conservative / fail-closed: only the explicitly-enumerated
+  * lossless widenings are [[MigrationCompatibility.BackwardsCompatible]]; their reverses are
+  * narrowings, and every other cross-type change is [[TypeComparison.Changed]] -- all
+  * [[MigrationCompatibility.Incompatible]]. `Array` delegates to its element type.
+  */
+enum TypeComparison {
+
+  case Same(tpe: Column.Type)
+  case Widening(fromType: Column.Type, toType: Column.Type)
+  case Narrowing(fromType: Column.Type, toType: Column.Type)
+  case Changed(fromType: Column.Type, toType: Column.Type)
+  case ArrayElem(fromType: Column.Type, toType: Column.Type, underlying: TypeComparison)
+
+  lazy val compatibility: MigrationCompatibility = this match
+    case _: TypeComparison.Same         => MigrationCompatibility.BackwardsCompatible
+    case _: TypeComparison.Widening     => MigrationCompatibility.BackwardsCompatible
+    case _: TypeComparison.Narrowing    => MigrationCompatibility.Incompatible
+    case _: TypeComparison.Changed      => MigrationCompatibility.Incompatible
+    case self: TypeComparison.ArrayElem => self.underlying.compatibility
+
+  final def isCompatible: Boolean = compatibility == MigrationCompatibility.BackwardsCompatible
+
+  final def isDifferent: Boolean = this match
+    case _: TypeComparison.Same         => false
+    case self: TypeComparison.ArrayElem => self.underlying.isDifferent
+    case _                              => true
+
+  def toIndentedString: IndentedString = this match
+    case TypeComparison.Same(tpe)              => s"Same(${tpe.show})"
+    case TypeComparison.Widening(f, t)         => s"Widening(${f.show} -> ${t.show})"
+    case TypeComparison.Narrowing(f, t)        => s"Narrowing(${f.show} -> ${t.show})"
+    case TypeComparison.Changed(f, t)          => s"Changed(${f.show} -> ${t.show})"
+    case TypeComparison.ArrayElem(f, t, under) => IndentedString.keyValueSection(s"ArrayElem(${f.show} -> ${t.show}):")("elem: " -> under.toIndentedString)
+
+}
+object TypeComparison {
+
+  /**
+    * Directed lossless-widening pairs (Postgres-safe). A transition present here is a widening; its
+    * reverse is a narrowing; anything else is [[TypeComparison.Changed]] (fail-closed incompatible).
+    */
+  private val wideningPairs: Set[(Column.Type, Column.Type)] =
+    Set(
+      (Column.Type.SmallInt, Column.Type.Int),
+      (Column.Type.SmallInt, Column.Type.BigInt),
+      (Column.Type.Int, Column.Type.BigInt),
+      (Column.Type.Real, Column.Type.DoublePrecision),
+    )
+
+  def compare(from: Column.Type, to: Column.Type): TypeComparison =
+    (from, to) match
+      case (a, b) if a == b                             => TypeComparison.Same(a)
+      case (Column.Type.Array(a), Column.Type.Array(b)) => TypeComparison.ArrayElem(from, to, compare(a, b))
+      case (f, t) if wideningPairs.contains((f, t))     => TypeComparison.Widening(f, t)
+      case (f, t) if wideningPairs.contains((t, f))     => TypeComparison.Narrowing(f, t)
+      case (f, t)                                       => TypeComparison.Changed(f, t)
+
+}

--- a/modules/sql/migration/src/test/scala/oxygen/sql/migration/compat/DbCompatibilitySpecSpec.scala
+++ b/modules/sql/migration/src/test/scala/oxygen/sql/migration/compat/DbCompatibilitySpecSpec.scala
@@ -1,0 +1,202 @@
+package oxygen.sql.migration.compat
+
+import oxygen.predef.test.*
+import oxygen.sql.migration.model.*
+import oxygen.sql.migration.model.EntityRef.*
+import oxygen.sql.migration.persistence.model.MigrationCompatibility
+import oxygen.sql.schema.Column
+
+object DbCompatibilitySpecSpec extends OxygenSpecDefault {
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////////
+  //      Builders
+  //////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  private def tableRef(name: String): TableRef = EntityRef.TableRef("public", name)
+
+  private def table(
+      name: String,
+      pk: ArraySeq[Column],
+      columns: ArraySeq[Column],
+      foreignKeys: ArraySeq[ForeignKeyState],
+      indices: ArraySeq[IndexState],
+  ): TableState =
+    TableState(tableRef(name), pk, columns, foreignKeys, indices)
+
+  private def simpleTable(name: String, columns: ArraySeq[Column]): TableState =
+    table(name, ArraySeq.empty, columns, ArraySeq.empty, ArraySeq.empty)
+
+  private def state(tables: TableState*): MigrationState =
+    MigrationState(Set.empty, Set(SchemaRef("public")), tables.map(t => t.tableName -> t).toMap)
+
+  private val idCol: Column = Column("id", Column.Type.UUID, nullable = false)
+
+  private def index(table: String, unique: Boolean, columns: String*): IndexState =
+    IndexState(None, tableRef(table), unique, ArraySeq.from(columns))
+
+  private def foreignKey(self: String, references: String, column: String): ForeignKeyState =
+    ForeignKeyState(None, tableRef(self), tableRef(references), ArraySeq(ForeignKeyState.Pair(column, "id")))
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////////
+  //      Assertions
+  //////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  private def assertCompatible(from: MigrationState, to: MigrationState) = {
+    val result = DbCompatibilitySpec.compare(from, to)
+    assertTrue(
+      result.compatibility == MigrationCompatibility.BackwardsCompatible,
+      result.isCompatible,
+    )
+  }
+
+  private def assertIncompatible(from: MigrationState, to: MigrationState) = {
+    val result = DbCompatibilitySpec.compare(from, to)
+    assertTrue(
+      result.compatibility == MigrationCompatibility.Incompatible,
+      !result.isCompatible,
+    )
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////////
+  //      Tests
+  //////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  private val typeCompareSpec: TestSpec =
+    suite("TypeComparison.compare")(
+      test("identical is Same + compatible") {
+        val c = TypeComparison.compare(Column.Type.Int, Column.Type.Int)
+        assertTrue(c == TypeComparison.Same(Column.Type.Int), c.isCompatible, !c.isDifferent)
+      },
+      test("SmallInt -> Int -> BigInt widen (compatible)") {
+        assertTrue(
+          TypeComparison.compare(Column.Type.SmallInt, Column.Type.Int).isCompatible,
+          TypeComparison.compare(Column.Type.SmallInt, Column.Type.BigInt).isCompatible,
+          TypeComparison.compare(Column.Type.Int, Column.Type.BigInt).isCompatible,
+          TypeComparison.compare(Column.Type.Real, Column.Type.DoublePrecision).isCompatible,
+        )
+      },
+      test("reverse of a widening narrows (incompatible)") {
+        assertTrue(
+          !TypeComparison.compare(Column.Type.Int, Column.Type.SmallInt).isCompatible,
+          !TypeComparison.compare(Column.Type.BigInt, Column.Type.Int).isCompatible,
+          !TypeComparison.compare(Column.Type.DoublePrecision, Column.Type.Real).isCompatible,
+        )
+      },
+      test("cross-kind change fails closed") {
+        assertTrue(
+          !TypeComparison.compare(Column.Type.Int, Column.Type.Text).isCompatible,
+          !TypeComparison.compare(Column.Type.Int, Column.Type.Numeric).isCompatible,
+          !TypeComparison.compare(Column.Type.Json, Column.Type.Jsonb).isCompatible,
+        )
+      },
+      test("Array delegates to its element type") {
+        assertTrue(
+          TypeComparison.compare(Column.Type.Array(Column.Type.SmallInt), Column.Type.Array(Column.Type.Int)).isCompatible,
+          !TypeComparison.compare(Column.Type.Array(Column.Type.Int), Column.Type.Array(Column.Type.SmallInt)).isCompatible,
+        )
+      },
+    )
+
+  private val columnSpec: TestSpec = {
+    val base = state(simpleTable("foo", ArraySeq(idCol, Column("age", Column.Type.Int, nullable = false))))
+    suite("columns")(
+      test("identical states are compatible + not different") {
+        assertCompatible(base, base) &&
+        assertTrue(!DbCompatibilitySpec.compare(base, base).isDifferent)
+      },
+      test("add nullable column is compatible") {
+        val to = state(simpleTable("foo", ArraySeq(idCol, Column("age", Column.Type.Int, nullable = false), Column("nick", Column.Type.Text, nullable = true))))
+        assertCompatible(base, to)
+      },
+      test("add non-nullable column is incompatible") {
+        val to = state(simpleTable("foo", ArraySeq(idCol, Column("age", Column.Type.Int, nullable = false), Column("nick", Column.Type.Text, nullable = false))))
+        assertIncompatible(base, to)
+      },
+      test("drop column is incompatible") {
+        val to = state(simpleTable("foo", ArraySeq(idCol)))
+        assertIncompatible(base, to)
+      },
+      test("relax NOT NULL -> NULL is compatible") {
+        val to = state(simpleTable("foo", ArraySeq(idCol, Column("age", Column.Type.Int, nullable = true))))
+        assertCompatible(base, to)
+      },
+      test("tighten NULL -> NOT NULL is incompatible") {
+        val nullableBase = state(simpleTable("foo", ArraySeq(idCol, Column("age", Column.Type.Int, nullable = true))))
+        assertIncompatible(nullableBase, base)
+      },
+      test("column type widening compatible, narrowing incompatible") {
+        val widened = state(simpleTable("foo", ArraySeq(idCol, Column("age", Column.Type.BigInt, nullable = false))))
+        assertCompatible(base, widened) && assertIncompatible(widened, base)
+      },
+    )
+  }
+
+  private val tableSpec: TestSpec = {
+    val base = state(simpleTable("foo", ArraySeq(idCol)))
+    suite("tables")(
+      test("add table is compatible") {
+        val to = state(simpleTable("foo", ArraySeq(idCol)), simpleTable("bar", ArraySeq(idCol)))
+        assertCompatible(base, to)
+      },
+      test("drop table is incompatible") {
+        val from = state(simpleTable("foo", ArraySeq(idCol)), simpleTable("bar", ArraySeq(idCol)))
+        assertIncompatible(from, base)
+      },
+      test("empty-table exception: constraints on a NEW table are compatible") {
+        // A newly-added table with a non-nullable column AND a unique index is still compatible,
+        // because the table is empty (the whole table lives in the `added` bucket).
+        val newTable =
+          table(
+            "bar",
+            ArraySeq(idCol),
+            ArraySeq(idCol, Column("email", Column.Type.Text, nullable = false)),
+            ArraySeq.empty,
+            ArraySeq(index("bar", unique = true, "email")),
+          )
+        assertCompatible(base, state(simpleTable("foo", ArraySeq(idCol)), newTable))
+      },
+      test("PK change on an existing table is incompatible") {
+        val from = state(table("foo", ArraySeq(idCol), ArraySeq(idCol, Column("k", Column.Type.Text, nullable = false)), ArraySeq.empty, ArraySeq.empty))
+        val to = state(table(
+          "foo",
+          ArraySeq(Column("k", Column.Type.Text, nullable = false)),
+          ArraySeq(idCol, Column("k", Column.Type.Text, nullable = false)),
+          ArraySeq.empty,
+          ArraySeq.empty,
+        ))
+        assertIncompatible(from, to)
+      },
+    )
+  }
+
+  private val constraintSpec: TestSpec = {
+    val base = state(table("foo", ArraySeq(idCol), ArraySeq(idCol, Column("owner", Column.Type.UUID, nullable = false)), ArraySeq.empty, ArraySeq.empty))
+    suite("constraints on existing tables")(
+      test("add unique index is incompatible") {
+        val to = state(table("foo", ArraySeq(idCol), ArraySeq(idCol, Column("owner", Column.Type.UUID, nullable = false)), ArraySeq.empty, ArraySeq(index("foo", unique = true, "owner"))))
+        assertIncompatible(base, to)
+      },
+      test("add non-unique index is compatible") {
+        val to = state(table("foo", ArraySeq(idCol), ArraySeq(idCol, Column("owner", Column.Type.UUID, nullable = false)), ArraySeq.empty, ArraySeq(index("foo", unique = false, "owner"))))
+        assertCompatible(base, to)
+      },
+      test("drop index is compatible") {
+        val from = state(table("foo", ArraySeq(idCol), ArraySeq(idCol, Column("owner", Column.Type.UUID, nullable = false)), ArraySeq.empty, ArraySeq(index("foo", unique = true, "owner"))))
+        assertCompatible(from, base)
+      },
+      test("add foreign key to an existing table is incompatible") {
+        val to = state(table("foo", ArraySeq(idCol), ArraySeq(idCol, Column("owner", Column.Type.UUID, nullable = false)), ArraySeq(foreignKey("foo", "bar", "owner")), ArraySeq.empty))
+        assertIncompatible(base, to)
+      },
+    )
+  }
+
+  override def testSpec: TestSpec =
+    suite("DbCompatibilitySpecSpec")(
+      typeCompareSpec,
+      columnSpec,
+      tableSpec,
+      constraintSpec,
+    )
+
+}


### PR DESCRIPTION
Adds a pure, DB-free **compatibility spec for the DB migration schema** — the DB analogue of the HTTP-schema `oxygen.schema.compat` lattice, and the richer, type-aware counterpart to the coarse `MigrationGenerator.classify` gate.

## What

New package `oxygen.sql.migration.compat` (module `oxygen-sql-migration`):

- **`DbCompatibilitySpec.compare(from: MigrationState, to: MigrationState): DbComparisonResult`** — the pure entry point. Diffs extensions, schemas, and every table (added / removed / changed), and within a changed table its columns, primary key, foreign keys, and indices.
- **`TypeComparison`** — per-`Column.Type` verdict (`Same`/`Widening`/`Narrowing`/`Changed`/`ArrayElem`), fail-closed: only `SMALLINT→INT→BIGINT` and `REAL→DOUBLE PRECISION` widen (compatible); their reverses narrow; `Array` delegates to its element; every other transition is incompatible.
- **`DbComparisonResult`** (+ nested `TableComparison`/`ColumnComparison`/`ConstraintComparison`) — reuses `FromToValues`/`AddedRemovedBoth` from `oxygen.schema.compat`; exposes `toIndentedString`/`pruned`/`isDifferent` and **collapses to the binary `MigrationCompatibility`** the harness already consumes, so the rich diagnostics never disagree with the coarse gate.

## Notes

- **Spec-only** — this is a diagnostic lens over two schema states, not a new gate; `MigrationCheck`/`MigrationGenerator` are untouched (a clean follow-up could route them through the richer result).
- Rules **agree with `MigrationGenerator.classifyOne`** where they overlap; the one addition is column-type widening/narrowing (which the flag ignores). The empty-table constraint exception falls out **structurally** (constraints on a freshly-added table live in the `added` bucket).
- Pure **unit tests, no DB** (20 tests) covering each rule; docs added to `docs/docs/sql/migrations.md`.

## Verification

- `oxygen-sql-migration/Test/compile` — green
- `oxygen-sql-migration/testOnly *DbCompatibilitySpecSpec` — 20 passed, 0 failed
- `scalafmt` (Compile + Test) — clean

Jira: OFF-341