### PR TITLE
OFF-338: Support explicitly naming FK + IDX

### DIFF
--- a/docs/docs/sql/models.md
+++ b/docs/docs/sql/models.md
@@ -32,6 +32,45 @@ Defined in `oxygen.sql.schema`:
 | `@primaryKey` | Field is part of the primary key (composite if on several fields) | — |
 | `@inlineColumnNames` | For an embedded case class, drop the field-name prefix on its columns | — |
 
+## Foreign keys & indices
+
+Foreign keys and indices can be declared at the **field** level or the **class** level:
+
+```scala
+final case class Note(
+    @primaryKey id: UUID,
+    @references[Person] personId: UUID,   // field-level FK -> Person's primary key
+    @indexed title: String,               // field-level (non-unique) index
+    @indexed.unique slug: String,         // field-level unique index
+)
+
+// class-level FK (supports composite keys) + class-level index over several columns
+@foreignKey[Order, Customer]((_.customerId, _.id))
+@index[Order](_.customerId, _.createdAt)
+@index.unique[Order](_.externalId)
+final case class Order(@primaryKey id: UUID, customerId: UUID, externalId: String, createdAt: Instant)
+```
+
+### Explicit constraint / index names
+
+By default the constraint and index names are **auto-generated** from the table, columns, and (for
+indices) uniqueness. Auto-names are stable but verbose, and they *change* if you rename a column. To
+pin a **stable, readable** name — handy for hand-written migrations — use the `.named` variants:
+
+| Auto-named | Explicitly named |
+|------------|------------------|
+| `@references[Person]` | `@references.named[Person]("fk_note_person")` |
+| `@foreignKey[A, B](…)` | `@foreignKey.named[A, B]("fk_name", …)` |
+| `@indexed` | `@indexed.named("idx_name")` |
+| `@indexed.unique` | `@indexed.unique.named("idx_name")` |
+| `@index[A](…)` | `@index.named[A]("idx_name", …)` |
+| `@index.unique[A](…)` | `@index.unique.named[A]("idx_name", …)` |
+
+The name is the **leading argument** (before the column selectors), and is validated at compile time
+(it must be a string literal). A blank name is treated as "auto-generate", so `.named("")` is
+equivalent to the plain annotation. Explicit names flow through to the generated DDL verbatim
+(`ADD CONSTRAINT fk_name …`, `CREATE UNIQUE INDEX idx_name …`).
+
 ## Companions & primary keys
 
 `TableCompanion[A, K]` takes the derived repr and is parameterized by the **primary key type** `K`:

--- a/modules/sql/core/src/main/scala/oxygen/sql/generic/typeclass/DeriveTableRepr.scala
+++ b/modules/sql/core/src/main/scala/oxygen/sql/generic/typeclass/DeriveTableRepr.scala
@@ -12,6 +12,12 @@ final class DeriveTableRepr[A: Type](
     instances: Expressions[RowRepr, A],
 )(using quotes: Quotes, fTpe: Type[RowRepr], generic: ProductGeneric[A]) {
 
+  /** Convert an explicit-name annotation argument into `Option[String]`: a blank/whitespace name means "auto-generate" (`None`). */
+  private def explicitNameExpr(nameExpr: Expr[String])(using Quotes): Expr[Option[String]] = {
+    val trimmed: String = nameExpr.valueOrAbort.trim
+    if trimmed.isEmpty then '{ Option.empty[String] } else '{ Some(${ Expr(trimmed) }) }
+  }
+
   private def schemaNameExpr: Expr[String] =
     Expr { generic.annotations.optionalOfValue[schemaName].fold("public")(_.name) }
 
@@ -106,16 +112,22 @@ final class DeriveTableRepr[A: Type](
     private def classForeignKey(expr: Expr[foreignKey[A, ?]])(using quotes: Quotes): Expr[ForeignKeyRepr[A, ?]] = {
       type RT
       given Type[RT] = expr match
-        case '{ `foreignKey`[A, rt](${ _ }*) }     => TypeRepr.of[rt].asTypeOf
-        case '{ new `foreignKey`[A, rt](${ _ }*) } => TypeRepr.of[rt].asTypeOf
-        case _                                     => report.errorAndAbort("unable to extract reference type", expr)
+        case '{ new `foreignKey`.`named`[A, rt]($_, ${ _ }*) } => TypeRepr.of[rt].asTypeOf
+        case '{ `foreignKey`[A, rt](${ _ }*) }                 => TypeRepr.of[rt].asTypeOf
+        case '{ new `foreignKey`[A, rt](${ _ }*) }             => TypeRepr.of[rt].asTypeOf
+        case _                                                 => report.errorAndAbort("unable to extract reference type", expr)
 
       val typedExpr: Expr[foreignKey[A, RT]] = expr.asExprOf[foreignKey[A, RT]]
 
+      val explicitName: Expr[Option[String]] = typedExpr match
+        case '{ new `foreignKey`.`named`[A, RT]($name, ${ _ }*) } => explicitNameExpr(name)
+        case _                                                    => '{ Option.empty[String] }
+
       val pairsList: Seq[Expr[(A => Any, RT => Any)]] = typedExpr match
-        case '{ `foreignKey`[A, RT](${ Varargs(exprs) }*) }     => exprs
-        case '{ new `foreignKey`[A, RT](${ Varargs(exprs) }*) } => exprs
-        case _                                                  => report.errorAndAbort("unable to extract foreign key expr pairs", expr)
+        case '{ new `foreignKey`.`named`[A, RT]($_, ${ Varargs(exprs) }*) } => exprs
+        case '{ `foreignKey`[A, RT](${ Varargs(exprs) }*) }                 => exprs
+        case '{ new `foreignKey`[A, RT](${ Varargs(exprs) }*) }             => exprs
+        case _                                                              => report.errorAndAbort("unable to extract foreign key expr pairs", expr)
 
       type RT_FK
       val rtGeneric: ProductGeneric[RT] = ProductGeneric.of[RT]
@@ -143,7 +155,7 @@ final class DeriveTableRepr[A: Type](
 
       '{
         ForeignKeyRepr[A, RT](
-          None, // TODO (KR) : allow for explicit fk naming
+          $explicitName,
           Lazy { $rtTableReprExpr },
           currentTableRepr => ArraySeq(${ pairs.map(_.current.toColumns('currentTableRepr)).seqToArraySeqExpr }*).flatten,
           referencesTableRepr => ArraySeq(${ pairs.map(_.references.toColumns('referencesTableRepr)).seqToArraySeqExpr }*).flatten,
@@ -164,10 +176,15 @@ final class DeriveTableRepr[A: Type](
     private def fieldForeignKey[FT](field: generic.Field[FT], expr: Expr[references[?]])(using Quotes): Expr[ForeignKeyRepr[A, ?]] = {
       type RT
       given Type[RT] = expr match
-        case '{ `references`[rt]() }     => TypeRepr.of[rt].asTypeOf
-        case '{ new `references`[rt]() } => TypeRepr.of[rt].asTypeOf
-        case '{ new `references`[rt] }   => TypeRepr.of[rt].asTypeOf
-        case _                           => report.errorAndAbort("unable to extract reference type", expr)
+        case '{ new `references`.`named`[rt]($_) } => TypeRepr.of[rt].asTypeOf
+        case '{ `references`[rt]() }               => TypeRepr.of[rt].asTypeOf
+        case '{ new `references`[rt]() }           => TypeRepr.of[rt].asTypeOf
+        case '{ new `references`[rt] }             => TypeRepr.of[rt].asTypeOf
+        case _                                     => report.errorAndAbort("unable to extract reference type", expr)
+
+      val explicitName: Expr[Option[String]] = expr match
+        case '{ new `references`.`named`[rt]($name) } => explicitNameExpr(name)
+        case _                                        => '{ Option.empty[String] }
 
       type RT_FK
       val rtGeneric: ProductGeneric[RT] = ProductGeneric.of[RT]
@@ -188,7 +205,7 @@ final class DeriveTableRepr[A: Type](
 
       '{
         ForeignKeyRepr[A, RT](
-          None, // TODO (KR) : allow for explicit fk naming
+          $explicitName,
           Lazy { $rtTableReprExpr },
           currentTableRepr => ${ pair.current.toColumns('currentTableRepr) },
           referencesTableRepr => ${ pair.references.toColumns('referencesTableRepr) },
@@ -245,25 +262,34 @@ final class DeriveTableRepr[A: Type](
 
     private def classIndex(expr: Expr[index[A]])(using quotes: Quotes): Expr[IndexRepr[A]] = {
       val isUnique: Boolean = expr match
-        case '{ `index`[A](${ _ }*) }              => false
-        case '{ new `index`[A](${ _ }*) }          => false
-        case '{ `index`.`unique`[A](${ _ }*) }     => true
-        case '{ new `index`.`unique`[A](${ _ }*) } => true
-        case _                                     => report.errorAndAbort("unable to extract index uniqueness", expr)
+        case '{ new `index`.`unique`.`named`[A]($_, ${ _ }*) } => true
+        case '{ `index`.`unique`[A](${ _ }*) }                 => true
+        case '{ new `index`.`unique`[A](${ _ }*) }             => true
+        case '{ new `index`.`named`[A]($_, ${ _ }*) }          => false
+        case '{ `index`[A](${ _ }*) }                          => false
+        case '{ new `index`[A](${ _ }*) }                      => false
+        case _                                                 => report.errorAndAbort("unable to extract index uniqueness", expr)
+
+      val explicitName: Expr[Option[String]] = expr match
+        case '{ new `index`.`unique`.`named`[A]($name, ${ _ }*) } => explicitNameExpr(name)
+        case '{ new `index`.`named`[A]($name, ${ _ }*) }          => explicitNameExpr(name)
+        case _                                                    => '{ Option.empty[String] }
 
       val fieldList: Seq[Expr[A => Any]] = expr match
-        case '{ `index`[A](${ Varargs(exprs) }*) }              => exprs
-        case '{ new `index`[A](${ Varargs(exprs) }*) }          => exprs
-        case '{ `index`.`unique`[A](${ Varargs(exprs) }*) }     => exprs
-        case '{ new `index`.`unique`[A](${ Varargs(exprs) }*) } => exprs
-        case _                                                  => report.errorAndAbort("unable to extract index fields", expr)
+        case '{ new `index`.`unique`.`named`[A]($_, ${ Varargs(exprs) }*) } => exprs
+        case '{ new `index`.`named`[A]($_, ${ Varargs(exprs) }*) }          => exprs
+        case '{ `index`.`unique`[A](${ Varargs(exprs) }*) }                 => exprs
+        case '{ new `index`.`unique`[A](${ Varargs(exprs) }*) }             => exprs
+        case '{ `index`[A](${ Varargs(exprs) }*) }                          => exprs
+        case '{ new `index`[A](${ Varargs(exprs) }*) }                      => exprs
+        case _                                                              => report.errorAndAbort("unable to extract index fields", expr)
 
       val fields: Seq[IndexField[A, ?]] =
         fieldList.map { ff => IndexField.parse(generic, ff) }
 
       '{
         IndexRepr[A](
-          None, // TODO (KR) : allow for explicit fk naming
+          $explicitName,
           ${ Expr(isUnique) },
           currentTableRepr => ArraySeq(${ fields.map(_.toColumns('currentTableRepr)).seqToArraySeqExpr }*).flatten,
         )
@@ -281,18 +307,22 @@ final class DeriveTableRepr[A: Type](
     }
 
     private def fieldIndex[FT](field: generic.Field[FT], expr: Expr[indexed])(using Quotes): Expr[IndexRepr[A]] = {
-      val isUnique: Boolean = expr match
-        case '{ `indexed`() }              => false
-        case '{ new `indexed`() }          => false
-        case '{ `indexed`.`unique`() }     => true
-        case '{ new `indexed`.`unique`() } => true
-        case _                             => report.errorAndAbort("unable to extract index uniqueness", expr)
+      val (explicitName, isUnique): (Expr[Option[String]], Boolean) = expr match
+        case '{ new `indexed`.`unique`.`named`($name) } => (explicitNameExpr(name), true)
+        case '{ new `indexed`.`named`($name) }          => (explicitNameExpr(name), false)
+        case '{ `indexed`.`unique`() }                  => ('{ Option.empty[String] }, true)
+        case '{ new `indexed`.`unique`() }              => ('{ Option.empty[String] }, true)
+        case '{ new `indexed`.`unique` }                => ('{ Option.empty[String] }, true)
+        case '{ `indexed`() }                           => ('{ Option.empty[String] }, false)
+        case '{ new `indexed`() }                       => ('{ Option.empty[String] }, false)
+        case '{ new `indexed` }                         => ('{ Option.empty[String] }, false)
+        case _                                          => report.errorAndAbort("unable to extract index uniqueness", expr)
 
       val idxField: IndexField[A, ?] = IndexField(generic, field)
 
       '{
         IndexRepr[A](
-          None, // TODO (KR) : allow for explicit idx naming
+          $explicitName,
           ${ Expr(isUnique) },
           currentTableRepr => ${ idxField.toColumns('currentTableRepr) },
         )

--- a/modules/sql/core/src/main/scala/oxygen/sql/schema/annotations.scala
+++ b/modules/sql/core/src/main/scala/oxygen/sql/schema/annotations.scala
@@ -39,15 +39,68 @@ final case class inlineColumnNames() extends StaticAnnotation derives FromExprT
   */
 final case class primaryKey() extends StaticAnnotation derives FromExprT
 
-final case class references[References]() extends StaticAnnotation
-final class foreignKey[Current, References](refs: (Current => Any, References => Any)*) extends StaticAnnotation
+/**
+  * Marks a field as a foreign key referencing `References`; the constraint is auto-named.
+  *
+  * To pin an explicit constraint name, use [[references.named]].
+  */
+class references[References]() extends StaticAnnotation
+object references {
 
+  /** A field-level foreign key with an explicit constraint `name`. */
+  final class named[References](val name: String) extends references[References]
+
+}
+
+/**
+  * Defines a class-level foreign key from `Current` to `References`; the constraint is auto-named.
+  *
+  * To pin an explicit constraint name, use [[foreignKey.named]].
+  */
+class foreignKey[Current, References](refs: (Current => Any, References => Any)*) extends StaticAnnotation
+object foreignKey {
+
+  /** A class-level foreign key with an explicit constraint `name`. */
+  final class named[Current, References](val name: String, refs: (Current => Any, References => Any)*) extends foreignKey[Current, References](refs*)
+
+}
+
+/**
+  * Marks a field as indexed; the index is auto-named.
+  *
+  * `indexed.unique` for a unique index; `indexed.named` / `indexed.unique.named` to pin an explicit index name.
+  */
 class indexed extends StaticAnnotation
 object indexed {
   class unique extends indexed
+  object unique {
+
+    /** A field-level unique index with an explicit `name`. */
+    final class named(val name: String) extends indexed.unique
+
+  }
+
+  /** A field-level index with an explicit `name`. */
+  final class named(val name: String) extends indexed
+
 }
 
+/**
+  * Defines a class-level index over the given columns; the index is auto-named.
+  *
+  * `index.unique` for a unique index; `index.named` / `index.unique.named` to pin an explicit index name.
+  */
 class index[Current](cols: (Current => Any)*) extends StaticAnnotation
 object index {
   class unique[Current](cols: (Current => Any)*) extends index[Current](cols*)
+  object unique {
+
+    /** A class-level unique index with an explicit `name`. */
+    final class named[Current](val name: String, cols: (Current => Any)*) extends index.unique[Current](cols*)
+
+  }
+
+  /** A class-level index with an explicit `name`. */
+  final class named[Current](val name: String, cols: (Current => Any)*) extends index[Current](cols*)
+
 }

--- a/modules/sql/core/src/test/scala/oxygen/sql/schema/ExplicitNamingSpec.scala
+++ b/modules/sql/core/src/test/scala/oxygen/sql/schema/ExplicitNamingSpec.scala
@@ -1,0 +1,102 @@
+package oxygen.sql.schema
+
+import java.util.UUID
+import oxygen.predef.test.*
+import oxygen.sql.query.TableCompanion
+
+object ExplicitNamingSpec extends OxygenSpecDefault {
+
+  final case class Parent(@primaryKey id: UUID, name: String)
+  object Parent extends TableCompanion[Parent, UUID](TableRepr.derived[Parent])
+
+  // --- field-level foreign keys (@references) ---
+
+  final case class ChildFkAuto(@primaryKey id: UUID, @references[Parent] parentId: UUID)
+  object ChildFkAuto extends TableCompanion[ChildFkAuto, UUID](TableRepr.derived[ChildFkAuto])
+
+  final case class ChildFkNamed(@primaryKey id: UUID, @references.named[Parent]("fk_child_parent") parentId: UUID)
+  object ChildFkNamed extends TableCompanion[ChildFkNamed, UUID](TableRepr.derived[ChildFkNamed])
+
+  // --- class-level foreign keys (@foreignKey) ---
+
+  @foreignKey[ClassFkAuto, Parent]((_.parentId, _.id))
+  final case class ClassFkAuto(@primaryKey id: UUID, parentId: UUID)
+  object ClassFkAuto extends TableCompanion[ClassFkAuto, UUID](TableRepr.derived[ClassFkAuto])
+
+  @foreignKey.named[ClassFkNamed, Parent]("fk_class_parent", (_.parentId, _.id))
+  final case class ClassFkNamed(@primaryKey id: UUID, parentId: UUID)
+  object ClassFkNamed extends TableCompanion[ClassFkNamed, UUID](TableRepr.derived[ClassFkNamed])
+
+  // --- field-level indices (@indexed) ---
+
+  final case class IdxFieldAuto(@primaryKey id: UUID, @indexed name: String)
+  object IdxFieldAuto extends TableCompanion[IdxFieldAuto, UUID](TableRepr.derived[IdxFieldAuto])
+
+  final case class IdxFieldNamed(@primaryKey id: UUID, @indexed.named("idx_field_name") name: String)
+  object IdxFieldNamed extends TableCompanion[IdxFieldNamed, UUID](TableRepr.derived[IdxFieldNamed])
+
+  final case class IdxFieldUniqueNamed(@primaryKey id: UUID, @indexed.unique.named("idx_field_u_name") name: String)
+  object IdxFieldUniqueNamed extends TableCompanion[IdxFieldUniqueNamed, UUID](TableRepr.derived[IdxFieldUniqueNamed])
+
+  // --- class-level indices (@index) ---
+
+  @index[ClassIdxAuto](_.a, _.b)
+  final case class ClassIdxAuto(@primaryKey id: UUID, a: Int, b: Int)
+  object ClassIdxAuto extends TableCompanion[ClassIdxAuto, UUID](TableRepr.derived[ClassIdxAuto])
+
+  @index.named[ClassIdxNamed]("idx_class_name", _.a, _.b)
+  final case class ClassIdxNamed(@primaryKey id: UUID, a: Int, b: Int)
+  object ClassIdxNamed extends TableCompanion[ClassIdxNamed, UUID](TableRepr.derived[ClassIdxNamed])
+
+  @index.unique.named[ClassIdxUniqueNamed]("idx_class_u_name", _.a)
+  final case class ClassIdxUniqueNamed(@primaryKey id: UUID, a: Int)
+  object ClassIdxUniqueNamed extends TableCompanion[ClassIdxUniqueNamed, UUID](TableRepr.derived[ClassIdxUniqueNamed])
+
+  private def onlyFk(repr: TableRepr[?]): ForeignKeyRepr[?, ?] = repr.foreignKeys.head
+  private def onlyIdx(repr: TableRepr[?]): IndexRepr[?] = repr.indices.head
+
+  override def testSpec: TestSpec =
+    suite("ExplicitNamingSpec")(
+      suite("foreign keys")(
+        test("field-level @references is auto-named") {
+          assertTrue(onlyFk(ChildFkAuto.tableRepr).explicitName.isEmpty)
+        },
+        test("field-level @references.named carries the explicit name") {
+          assertTrue(onlyFk(ChildFkNamed.tableRepr).explicitName.contains("fk_child_parent"))
+        },
+        test("class-level @foreignKey is auto-named") {
+          assertTrue(onlyFk(ClassFkAuto.tableRepr).explicitName.isEmpty)
+        },
+        test("class-level @foreignKey.named carries the explicit name") {
+          assertTrue(onlyFk(ClassFkNamed.tableRepr).explicitName.contains("fk_class_parent"))
+        },
+      ),
+      suite("indices")(
+        test("field-level @indexed is auto-named and non-unique") {
+          val idx = onlyIdx(IdxFieldAuto.tableRepr)
+          assertTrue(idx.explicitName.isEmpty, !idx.unique)
+        },
+        test("field-level @indexed.named carries the explicit name") {
+          val idx = onlyIdx(IdxFieldNamed.tableRepr)
+          assertTrue(idx.explicitName.contains("idx_field_name"), !idx.unique)
+        },
+        test("field-level @indexed.unique.named carries the explicit name and is unique") {
+          val idx = onlyIdx(IdxFieldUniqueNamed.tableRepr)
+          assertTrue(idx.explicitName.contains("idx_field_u_name"), idx.unique)
+        },
+        test("class-level @index is auto-named") {
+          val idx = onlyIdx(ClassIdxAuto.tableRepr)
+          assertTrue(idx.explicitName.isEmpty, !idx.unique)
+        },
+        test("class-level @index.named carries the explicit name") {
+          val idx = onlyIdx(ClassIdxNamed.tableRepr)
+          assertTrue(idx.explicitName.contains("idx_class_name"), !idx.unique)
+        },
+        test("class-level @index.unique.named carries the explicit name and is unique") {
+          val idx = onlyIdx(ClassIdxUniqueNamed.tableRepr)
+          assertTrue(idx.explicitName.contains("idx_class_u_name"), idx.unique)
+        },
+      ),
+    )
+
+}

--- a/modules/sql/it-test/src/test/scala/oxygen/sql/migration/ExplicitNamingMigrationSpec.scala
+++ b/modules/sql/it-test/src/test/scala/oxygen/sql/migration/ExplicitNamingMigrationSpec.scala
@@ -1,0 +1,65 @@
+package oxygen.sql.migration
+
+import java.util.UUID
+import oxygen.predef.test.*
+import oxygen.sql.migration.delta.MigrationPlanner
+import oxygen.sql.migration.model.MigrationState
+import oxygen.sql.migration.persistence.MigrationQueries
+import oxygen.sql.query.TableCompanion
+import oxygen.sql.schema.*
+import scala.collection.immutable.ArraySeq
+
+object ExplicitNamingMigrationSpec extends OxygenSpecDefault {
+
+  @tableName("mig_parent")
+  final case class MigParent(@primaryKey id: UUID, name: String)
+  object MigParent extends TableCompanion[MigParent, UUID](TableRepr.derived[MigParent])
+
+  // explicit names on both the FK and the index
+  @tableName("mig_child")
+  @foreignKey.named[MigChild, MigParent]("fk_mig_child_parent", (_.parentId, _.id))
+  @index.unique.named[MigChild]("idx_mig_child_name", _.name)
+  final case class MigChild(@primaryKey id: UUID, parentId: UUID, name: String)
+  object MigChild extends TableCompanion[MigChild, UUID](TableRepr.derived[MigChild])
+
+  // auto-named counterpart, same shape
+  @tableName("mig_child_auto")
+  @foreignKey[MigChildAuto, MigParent]((_.parentId, _.id))
+  @index.unique[MigChildAuto](_.name)
+  final case class MigChildAuto(@primaryKey id: UUID, parentId: UUID, name: String)
+  object MigChildAuto extends TableCompanion[MigChildAuto, UUID](TableRepr.derived[MigChildAuto])
+
+  /** Genesis migration SQL (empty -> tables), joined for substring assertions. */
+  private def genesisSql(reprs: TableRepr[?]*): String = {
+    val state: MigrationState =
+      MigrationState.fromTables(ArraySeq.from(reprs)) match
+        case Right(s)    => s
+        case Left(error) => throw new RuntimeException(s"could not derive state: $error")
+    val diffs =
+      MigrationPlanner.diffStates(MigrationState.empty, state) match
+        case Right(d)    => d
+        case Left(error) => throw new RuntimeException(s"could not diff states: $error")
+    diffs.map(MigrationQueries.diffToQuery(_).ctx.sql).mkString("\n")
+  }
+
+  override def testSpec: TestSpec =
+    suite("ExplicitNamingMigrationSpec")(
+      test("explicit FK + index names are emitted verbatim in the migration DDL") {
+        val sql = genesisSql(MigParent.tableRepr, MigChild.tableRepr)
+        assertTrue(
+          sql.contains("ADD CONSTRAINT fk_mig_child_parent"),
+          sql.contains("CREATE UNIQUE INDEX idx_mig_child_name"),
+        )
+      },
+      test("auto-named FK + index fall back to generated names (no explicit literal)") {
+        val sql = genesisSql(MigParent.tableRepr, MigChildAuto.tableRepr)
+        assertTrue(
+          sql.contains("ADD CONSTRAINT fk____"),
+          sql.contains("CREATE UNIQUE INDEX idx_u____"),
+          !sql.contains("fk_mig_child_parent"),
+          !sql.contains("idx_mig_child_name"),
+        )
+      },
+    )
+
+}


### PR DESCRIPTION
Wire explicit constraint/index names through `oxygen-sql` table derivation. The downstream plumbing (`ForeignKeyRepr`/`IndexRepr` `explicitName`, `ForeignKeyState`/`IndexState` fallback to auto-names, migration DDL emitting the resolved name) already existed; the four `DeriveTableRepr` sites hard-coding `None` were the only gap.

## Approach

Overloading the annotation constructors (auto vs. named) breaks Scala 3 quote pattern-matching — a class with two constructors makes every `'{ … }` pattern fail to type. Instead, keep the existing annotations **unchanged** (backwards compatible, auto-named) and add single-constructor `.named` subclasses, mirroring the existing `index.unique` nesting:

| Auto-named | Explicitly named |
|---|---|
| `@references[T]` | `@references.named[T]("fk_name")` |
| `@foreignKey[A,B](…)` | `@foreignKey.named[A,B]("fk_name", …)` |
| `@indexed` | `@indexed.named("idx_name")` |
| `@indexed.unique` | `@indexed.unique.named("idx_name")` |
| `@index[A](…)` | `@index.named[A]("idx_name", …)` |
| `@index.unique[A](…)` | `@index.unique.named[A]("idx_name", …)` |

The name is the leading argument, validated at compile time (must be a string literal); a blank name trims to `None` (auto).

## Tests

- **`ExplicitNamingSpec`** (oxygen-sql) — derivation asserts `explicitName` is populated for every named variant (FK/IDX × class/field × unique) and empty for auto.
- **`ExplicitNamingMigrationSpec`** (sql-it) — round-trip asserts the generated DDL contains `ADD CONSTRAINT fk_…` / `CREATE UNIQUE INDEX idx_…` verbatim for named, and auto falls back to generated names.

Docs added to `docs/docs/sql/models.md` (Foreign keys & indices).

## Deferred (follow-up candidates)

Duplicate-name detection and the Postgres 63-byte / identifier-charset checks are left to Postgres at migrate-time (auto-names have no such guard today either).

Jira: OFF-338