### PR TITLE
OFF-352: Add compatibility checking for endpoint schema

### DIFF
--- a/agent-docs/http-docs/http-feature-plan.md
+++ b/agent-docs/http-docs/http-feature-plan.md
@@ -1,7 +1,8 @@
 # HTTP Docs — Feature Plan
 
-> Status: **Phases 1–3 implemented (1 & 2 tested); Phase 4 pending**
-> Modules: `modules/http/zio` (oxygen-http), `modules/general/schema` (oxygen-schema)
+> Status: **Phases 1–4 implemented & tested**
+> Modules: `modules/http/zio` (oxygen-http), `modules/http/test-utils` (oxygen-http-test),
+> `modules/general/schema` (oxygen-schema)
 
 ## Implementation status
 
@@ -10,7 +11,7 @@
 | 1 — Compiled HTTP spec | ✅ done | `oxygen.http.schema.compiled`: model (`RawCompiledApiSpec` & friends, `CompiledParamType`, `CompiledExpectedStatuses`) in pure cross src; `FullCompiledApiSpec` (resolved graph + `show`); `CompiledApiSpec.compile(Seq[EndpointSchema])` compiler in `.jvm`. Compiles JVM + JS. |
 | 2 — Serve via middleware | ✅ done | `ApiSpecEndpointMiddleware` (`.jvm/server`): compiles applied endpoints' schemas and appends a `GET /oxygen/api-spec` endpoint serving the spec as JSON. **Wired into `example-web-server`** (`WebServerMain` → `CompiledEndpoints.endpointLayer(endpointMiddleware = new ApiSpecEndpointMiddleware())`). |
 | 3 — UI rendering | ✅ done | `oxygen.ui.web.apispec.ApiSpecPage` (`RoutablePage.NoParams[RawClient]`): GETs `/oxygen/api-spec` via `RawClient`, decodes with `JsonCodec`, builds `FullCompiledApiSpec`, renders endpoints (grouped by API; method/path/params/bodies) + schema graph (products→fields, sums→cases; other variants fall back to `toIndentedString`). Registered in `example/apps/ui` (`UIMain`, route `/page/api-spec`) with a `RawClient.default` layer. Compiles JVM + JS. |
-| 4 — Compat detection | ⬜ pending | Decided: persist + diff via `oxygen.schema.compat`. Not started. |
+| 4 — Compat detection | ✅ done | `oxygen.http.schema.compat`: `HttpApiSpecComparison.compare(from, to)` (shared) diffs two `RawCompiledApiSpec`s into a binary gate + located breaking changes, honouring the request/response-opposite rule; `HttpApiSpecCheck` (`.jvm`) persists/diffs the committed JSON (mirrors `MigrationCheck`) with `Config(allowUpdate, allowIncompatible)` + `fromEnv` + `Outcome`. Reusable `ApiSpecCompatibilitySpec` in the new `oxygen-http-test` module (mirrors `DbMigrationSpec`). Compiles JVM + JS. |
 
 **Tests:** `modules/http/it-test/.../CompiledApiSpecSpec.scala` (5 tests, green) — compiles all
 6 `UserApi` endpoints, dedupes shared `User`, JSON round-trips, `FullCompiledApiSpec.show`
@@ -226,9 +227,55 @@ as-is for the *type* layer; we add the *endpoint/API* layer on top of it.
 - **Reference template:** the existing example UI app at `example/apps/ui` (`UIMain extends
   PageApp`, pages extend `RoutablePage`, fetches via `DeriveClient.clientLayer[...]`).
 
-### Phase 4 — API-incompatibility detection (eventually)
-- Persist the compiled spec (avro/sql-migration paradigm), diff via `oxygen.schema.compat`
-  extended to the endpoint/API layer, fail CI on breaking changes; env-var-gated update.
+### Phase 4 — API-incompatibility detection ✅ (OFF-352)
+Persist the compiled spec (avro/sql-migration paradigm), diff it at the endpoint/API layer, fail
+CI on breaking changes; env-var-gated update. Landed as:
+
+- **`HttpApiSpecComparison.compare(from, to): Result`** (`oxygen.http.schema.compat`, shared) — walks
+  the two `RawCompiledApiSpec`s and returns a binary `Compatibility` (Compatible / Incompatible) plus a
+  list of located `BreakingChange`s. **Request vs response are exact opposites**, per the author's tables:
+  one `Dir`-parameterised rule set drives both, so they can't drift. Request = old client writes / new
+  server reads (compatible ⇔ the server accepts a superset); response = the mirror.
+
+  | Field change | Request | Response |  | Sum-case change | Request | Response |
+  |---|---|---|---|---|---|---|
+  | add required | breaking | ok |  | add case | ok | breaking |
+  | add optional | ok | ok |  | remove case | breaking | ok |
+  | remove required | ok | breaking |  | | | |
+  | required→optional | ok | breaking |  | | | |
+  | optional→required | breaking | ok |  | | | |
+
+  Endpoint/API removed = breaking; added = ok. Status codes are not gated (oxygen-http de-emphasises
+  them — decoding keys off body discriminators).
+
+  > **Why not delegate to `oxygen.schema.compat`?** That engine resolves *both* refs against a single
+  > bundle (`eval(full, full)`), so it can only compare distinctly-identified types — it cannot compare
+  > two independently-compiled specs where a type keeps its name and changes in place (the common case
+  > here), and its `ByName`/`Full` constructors are `private[schema]` so the two sides can't be
+  > namespaced externally. So the endpoint layer resolves each side against **its own** bundle and walks
+  > the structure directly; per-type-shape verdicts mirror that engine, and unhandled/mismatched shapes
+  > fall back to structural equality (never a false "compatible"). A future two-bundle-aware `compare`
+  > (OXY-29 / OFF-369) could replace this walk.
+
+- **`HttpApiSpecCheck`** (`.jvm`) — mirrors `oxygen.sql.migration.MigrationCheck`:
+  `Config(allowUpdate, allowIncompatible)` + `Config.fromEnv` + `Outcome`
+  (`UpToDate` / `Wrote` / `PendingUpdate` / `BlockedIncompatible`) +
+  `check(path, currentSpec, config)`. Persists a single `RawCompiledApiSpec.withoutLineNos` JSON file;
+  a missing file is a genesis `PendingUpdate` / `Wrote`. Env-var gates:
+
+  | Env var | Effect |
+  |---|---|
+  | `OXYGEN_HTTP_ALLOW_UPDATE=true` | write the new committed spec instead of failing (else `PendingUpdate`) |
+  | `OXYGEN_HTTP_ALLOW_INCOMPATIBLE=true` | additionally permit a breaking change (else `BlockedIncompatible`) |
+
+- **`ApiSpecCompatibilitySpec`** (new module **`oxygen-http-test`**, `oxygen.http.test`) — a reusable
+  base mirroring `DbMigrationSpec`: a subclass supplies `apiSpecPath` + `currentEndpoints`; the single
+  test (`@@ TestAspect.withLiveEnvironment`) surfaces `PendingUpdate` / `BlockedIncompatible` as failures
+  with actionable messages. Harness + comparison tests live in `http-it`.
+
+**Deferred (follow-ups):** history-of-docs snapshots (the seed marked it optional); wiring an example
+app + committing an initial `oxygen-http-api-spec.json`; a two-bundle `oxygen.schema.compat.compare`
+(OXY-29 / OFF-369) that would let the endpoint layer reuse the schema engine directly.
 
 ---
 

--- a/build.sbt
+++ b/build.sbt
@@ -122,8 +122,7 @@ lazy val `oxygen-modules-jvm`: Project =
 
       // http
       `oxygen-http`.jvm,
-      // TODO (KR) : add
-      // `oxygen-http-test`.jvm,
+      `oxygen-http-test`,
 
       // jwt
       `oxygen-crypto-model`.jvm,
@@ -660,6 +659,19 @@ lazy val `oxygen-sql-test`: Project =
       `oxygen-sql-migration` % testAndCompile,
     )
 
+lazy val `oxygen-http-test`: Project =
+  project
+    .in(file("modules/http/test-utils"))
+    .settings(
+      publishedProjectSettings,
+      name := "oxygen-http-test",
+      description := "Test utils for oxygen-http (compiled-spec compatibility checking).",
+    )
+    .dependsOn(
+      `oxygen-http`.jvm % testAndCompile,
+      `oxygen-test`.jvm % testAndCompile,
+    )
+
 // TODO (KR) :
 // lazy val `oxygen-events-pulsar-test`: Project =
 //   project
@@ -719,9 +731,8 @@ lazy val `http-it`: Project =
       description := "http-it",
     )
     .dependsOn(
-      // TODO (KR) : replace
-      // `oxygen-http-test`
       `oxygen-http`.jvm % testAndCompile,
+      `oxygen-http-test` % testAndCompile,
     )
 
 lazy val `events-it`: Project =

--- a/modules/http/it-test/src/test/scala/oxygen/http/ApiSpecCompatFixtures.scala
+++ b/modules/http/it-test/src/test/scala/oxygen/http/ApiSpecCompatFixtures.scala
@@ -1,0 +1,76 @@
+package oxygen.http
+
+import oxygen.http.core.*
+import oxygen.http.schema.compiled.{CompiledApiSpec, RawCompiledApiSpec}
+import oxygen.http.server.DeriveEndpoints
+import oxygen.json.*
+import oxygen.predef.core.*
+import oxygen.schema.JsonSchema
+import scala.annotation.experimental
+import zio.*
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+//      Models -- two/three versions of a product and a sum
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+
+final case class Thing1(id: Int, name: String) derives JsonSchema
+final case class Thing2Req(id: Int, name: String, description: String) derives JsonSchema
+final case class Thing2Opt(id: Int, name: String, description: Option[String]) derives JsonSchema
+
+enum Shape2 derives JsonSchema {
+  case Circle(r: Double)
+  case Square(s: Double)
+}
+enum Shape3 derives JsonSchema {
+  case Circle(r: Double)
+  case Square(s: Double)
+  case Triangle(b: Double)
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+//      APIs -- request-only and response-only carriers of each model.
+//      Every version pins the SAME `@apiName` + endpoint (method) name so the diff pairs them.
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+
+@apiName("reqThing") @experimental trait ReqThingV1 { @route.post("/thing") def put(@param.body.json body: Thing1): UIO[Unit] }
+@apiName("reqThing") @experimental trait ReqThingV2Req { @route.post("/thing") def put(@param.body.json body: Thing2Req): UIO[Unit] }
+@apiName("reqThing") @experimental trait ReqThingV2Opt { @route.post("/thing") def put(@param.body.json body: Thing2Opt): UIO[Unit] }
+
+@apiName("respThing") @experimental trait RespThingV1 { @route.get("/thing") def get(): UIO[Thing1] }
+@apiName("respThing") @experimental trait RespThingV2Req { @route.get("/thing") def get(): UIO[Thing2Req] }
+
+@apiName("reqShape") @experimental trait ReqShapeV2 { @route.post("/shape") def put(@param.body.json body: Shape2): UIO[Unit] }
+@apiName("reqShape") @experimental trait ReqShapeV3 { @route.post("/shape") def put(@param.body.json body: Shape3): UIO[Unit] }
+
+@apiName("respShape") @experimental trait RespShapeV2 { @route.get("/shape") def get(): UIO[Shape2] }
+@apiName("respShape") @experimental trait RespShapeV3 { @route.get("/shape") def get(): UIO[Shape3] }
+
+@apiName("multi") @experimental trait MultiV1 { @route.get("/a") def a(): UIO[Thing1] }
+@apiName("multi") @experimental trait MultiV2 {
+  @route.get("/a") def a(): UIO[Thing1]
+  @route.get("/b") def b(): UIO[Thing1]
+}
+
+@experimental
+object ApiSpecCompatFixtures {
+
+  private def specOf[A](endpoints: DeriveEndpoints[A]): RawCompiledApiSpec =
+    CompiledApiSpec.compileWithoutLineNos(endpoints.endpoints.toArraySeq.map(_.schema))
+
+  val reqThingV1: RawCompiledApiSpec = specOf(DeriveEndpoints.derived: DeriveEndpoints[ReqThingV1])
+  val reqThingV2Req: RawCompiledApiSpec = specOf(DeriveEndpoints.derived: DeriveEndpoints[ReqThingV2Req])
+  val reqThingV2Opt: RawCompiledApiSpec = specOf(DeriveEndpoints.derived: DeriveEndpoints[ReqThingV2Opt])
+
+  val respThingV1: RawCompiledApiSpec = specOf(DeriveEndpoints.derived: DeriveEndpoints[RespThingV1])
+  val respThingV2Req: RawCompiledApiSpec = specOf(DeriveEndpoints.derived: DeriveEndpoints[RespThingV2Req])
+
+  val reqShapeV2: RawCompiledApiSpec = specOf(DeriveEndpoints.derived: DeriveEndpoints[ReqShapeV2])
+  val reqShapeV3: RawCompiledApiSpec = specOf(DeriveEndpoints.derived: DeriveEndpoints[ReqShapeV3])
+
+  val respShapeV2: RawCompiledApiSpec = specOf(DeriveEndpoints.derived: DeriveEndpoints[RespShapeV2])
+  val respShapeV3: RawCompiledApiSpec = specOf(DeriveEndpoints.derived: DeriveEndpoints[RespShapeV3])
+
+  val multiV1: RawCompiledApiSpec = specOf(DeriveEndpoints.derived: DeriveEndpoints[MultiV1])
+  val multiV2: RawCompiledApiSpec = specOf(DeriveEndpoints.derived: DeriveEndpoints[MultiV2])
+
+}

--- a/modules/http/it-test/src/test/scala/oxygen/http/HttpApiSpecCheckSpec.scala
+++ b/modules/http/it-test/src/test/scala/oxygen/http/HttpApiSpecCheckSpec.scala
@@ -1,0 +1,77 @@
+package oxygen.http
+
+import oxygen.http.schema.compat.HttpApiSpecCheck
+import oxygen.http.schema.compat.HttpApiSpecCheck.{Config, Outcome}
+import oxygen.predef.test.*
+import oxygen.zio.system.Path
+import scala.annotation.experimental
+import zio.*
+
+/**
+  * End-to-end tests of the persist-and-diff harness over throwaway temp files, exercising the four
+  * outcomes: genesis/stale -> `PendingUpdate`, write -> `Wrote`, unchanged -> `UpToDate`, and a breaking
+  * change -> `BlockedIncompatible` (unless `allowIncompatible`).
+  */
+@experimental
+object HttpApiSpecCheckSpec extends OxygenSpecDefault {
+
+  import ApiSpecCompatFixtures.*
+
+  private val ci: Config = Config.ci
+  private val update: Config = Config(allowUpdate = true, allowIncompatible = false)
+  private val updateIncompatible: Config = Config(allowUpdate = true, allowIncompatible = true)
+
+  private def freshPath: UIO[Path] =
+    for {
+      uuid <- Random.nextUUID
+      path <- Path.of(s"target/test-out/api-spec-check/$uuid.json").orDie
+    } yield path
+
+  extension (self: IO[HttpApiSpecCheck.HttpApiSpecCheckError, Outcome])
+    private def outcome: UIO[Outcome] = self.orDieWith(e => new RuntimeException(e.toString))
+
+  private def isPending(o: Outcome): Boolean = o match
+    case _: Outcome.PendingUpdate => true
+    case _                        => false
+  private def isWrote(o: Outcome): Boolean = o match
+    case _: Outcome.Wrote => true
+    case _                => false
+  private def isBlocked(o: Outcome): Boolean = o match
+    case _: Outcome.BlockedIncompatible => true
+    case _                              => false
+
+  override def testSpec: TestSpec =
+    suite("HttpApiSpecCheckSpec")(
+      test("a missing committed file is a PendingUpdate under CI") {
+        for {
+          path <- freshPath
+          o <- HttpApiSpecCheck.check(path, reqThingV1, ci).outcome
+        } yield assertTrue(isPending(o))
+      },
+      test("allowUpdate writes the genesis file, which then reads back as UpToDate") {
+        for {
+          path <- freshPath
+          wrote <- HttpApiSpecCheck.check(path, reqThingV1, update).outcome
+          exists <- path.exists.orDie
+          again <- HttpApiSpecCheck.check(path, reqThingV1, ci).outcome
+        } yield assertTrue(isWrote(wrote), exists, again == Outcome.UpToDate)
+      },
+      test("a compatible change is PendingUpdate under CI and Wrote under allowUpdate") {
+        for {
+          path <- freshPath
+          _ <- HttpApiSpecCheck.check(path, reqThingV1, update).outcome
+          pending <- HttpApiSpecCheck.check(path, reqThingV2Opt, ci).outcome
+          wrote <- HttpApiSpecCheck.check(path, reqThingV2Opt, update).outcome
+        } yield assertTrue(isPending(pending), isWrote(wrote))
+      },
+      test("a breaking change is BlockedIncompatible unless allowIncompatible is set") {
+        for {
+          path <- freshPath
+          _ <- HttpApiSpecCheck.check(path, reqThingV1, update).outcome
+          blocked <- HttpApiSpecCheck.check(path, reqThingV2Req, update).outcome
+          forced <- HttpApiSpecCheck.check(path, reqThingV2Req, updateIncompatible).outcome
+        } yield assertTrue(isBlocked(blocked), isWrote(forced))
+      },
+    ) @@ TestAspect.withLiveRandom // freshPath needs real UUIDs so temp files don't collide
+
+}

--- a/modules/http/it-test/src/test/scala/oxygen/http/HttpApiSpecComparisonSpec.scala
+++ b/modules/http/it-test/src/test/scala/oxygen/http/HttpApiSpecComparisonSpec.scala
@@ -1,0 +1,63 @@
+package oxygen.http
+
+import oxygen.http.schema.compat.HttpApiSpecComparison
+import oxygen.predef.test.*
+import scala.annotation.experimental
+
+/**
+  * Validates the endpoint/API-layer compatibility classifier against the ticket's two tables -- and in
+  * particular that **request and response compatibility are exact opposites** for the same structural
+  * change (`compare` takes `from` = old, `to` = new).
+  */
+@experimental
+object HttpApiSpecComparisonSpec extends OxygenSpecDefault {
+
+  import ApiSpecCompatFixtures.*
+
+  override def testSpec: TestSpec =
+    suite("HttpApiSpecComparisonSpec")(
+      test("identical specs are compatible with no breaking changes") {
+        val result = HttpApiSpecComparison.compare(reqThingV1, reqThingV1)
+        assertTrue(result.isCompatible, result.breakingChanges.isEmpty)
+      },
+      suite("request body -- client writes, server reads")(
+        test("adding a required field is breaking") {
+          assertTrue(!HttpApiSpecComparison.compare(reqThingV1, reqThingV2Req).isCompatible)
+        },
+        test("adding an optional field is compatible") {
+          assertTrue(HttpApiSpecComparison.compare(reqThingV1, reqThingV2Opt).isCompatible)
+        },
+        test("removing a required field is compatible") {
+          assertTrue(HttpApiSpecComparison.compare(reqThingV2Req, reqThingV1).isCompatible)
+        },
+        test("adding a sum-type case is compatible") {
+          assertTrue(HttpApiSpecComparison.compare(reqShapeV2, reqShapeV3).isCompatible)
+        },
+        test("removing a sum-type case is breaking") {
+          assertTrue(!HttpApiSpecComparison.compare(reqShapeV3, reqShapeV2).isCompatible)
+        },
+      ),
+      suite("response body -- server writes, client reads (the mirror image)")(
+        test("adding a required field is compatible") {
+          assertTrue(HttpApiSpecComparison.compare(respThingV1, respThingV2Req).isCompatible)
+        },
+        test("removing a required field is breaking") {
+          assertTrue(!HttpApiSpecComparison.compare(respThingV2Req, respThingV1).isCompatible)
+        },
+        test("adding a sum-type case is breaking") {
+          assertTrue(!HttpApiSpecComparison.compare(respShapeV2, respShapeV3).isCompatible)
+        },
+        test("removing a sum-type case is compatible") {
+          assertTrue(HttpApiSpecComparison.compare(respShapeV3, respShapeV2).isCompatible)
+        },
+      ),
+      test("removing an endpoint is breaking") {
+        val result = HttpApiSpecComparison.compare(multiV2, multiV1)
+        assertTrue(!result.isCompatible, result.breakingChanges.exists(_.detail == "endpoint removed"))
+      },
+      test("adding an endpoint is compatible") {
+        assertTrue(HttpApiSpecComparison.compare(multiV1, multiV2).isCompatible)
+      },
+    )
+
+}

--- a/modules/http/test-utils/src/main/scala/oxygen/http/test/ApiSpecCompatibilitySpec.scala
+++ b/modules/http/test-utils/src/main/scala/oxygen/http/test/ApiSpecCompatibilitySpec.scala
@@ -1,0 +1,55 @@
+package oxygen.http.test
+
+import oxygen.http.schema.compat.HttpApiSpecCheck
+import oxygen.http.schema.compat.HttpApiSpecCheck.{Config, Outcome}
+import oxygen.http.schema.compiled.CompiledApiSpec
+import oxygen.http.server.EndpointSchema
+import oxygen.predef.test.*
+import oxygen.zio.system.Path
+
+/**
+  * Reusable spec that guards the committed compiled HTTP API spec against the current-code endpoints --
+  * the endpoint-schema analogue of `oxygen.sql.test.DbMigrationSpec`. A subclass supplies the committed
+  * file path and the current endpoints; the spec fails CI when the committed doc is stale or when the
+  * change is incompatible for clients, with an actionable message naming the env vars to re-run with.
+  *
+  *   - `OXYGEN_HTTP_ALLOW_UPDATE=true` writes the new spec (review + commit it).
+  *   - `OXYGEN_HTTP_ALLOW_INCOMPATIBLE=true` additionally permits a breaking change.
+  */
+abstract class ApiSpecCompatibilitySpec extends OxygenSpecDefault {
+
+  /** Filesystem path of the committed spec JSON (resolved from the working dir). */
+  def apiSpecPath: String
+
+  /** The current-code endpoints (usually `summon[DeriveEndpoints[Api]].endpoints.toArraySeq.map(_.schema)`). */
+  def currentEndpoints: Seq[EndpointSchema]
+
+  def specName: String = getClass.getSimpleName
+
+  override final def testSpec: TestSpec =
+    suite(specName)(
+      test("committed api spec is up to date and compatible with the current endpoints") {
+        for {
+          path <- Path.of(apiSpecPath).orDie
+          config <- Config.fromEnv.orDie
+          spec = CompiledApiSpec.compileWithoutLineNos(currentEndpoints)
+          outcome <- HttpApiSpecCheck.check(path, spec, config).orDieWith(e => new RuntimeException(e.toString))
+        } yield outcome match
+          case Outcome.UpToDate =>
+            assertCompletes
+          case Outcome.Wrote(writtenTo) =>
+            assertCompletes.label(s"wrote api spec to $writtenTo -- review and commit it")
+          case Outcome.PendingUpdate(_) =>
+            assertTrue(false).label(
+              s"Committed api spec is out of date with the current endpoints. " +
+                s"Re-run with ${Config.allowUpdateEnv}=true to update it.",
+            )
+          case Outcome.BlockedIncompatible(comparison) =>
+            assertTrue(false).label(
+              s"Api spec change is incompatible (breaking for clients):\n${comparison.describe}\n" +
+                s"Re-run with ${Config.allowUpdateEnv}=true and ${Config.allowIncompatibleEnv}=true to allow it.",
+            )
+      } @@ TestAspect.withLiveEnvironment, // Config.fromEnv must read the real OS env, not zio-test's empty TestSystem
+    )
+
+}

--- a/modules/http/zio/.jvm/src/main/scala/oxygen/http/schema/compat/HttpApiSpecCheck.scala
+++ b/modules/http/zio/.jvm/src/main/scala/oxygen/http/schema/compat/HttpApiSpecCheck.scala
@@ -1,0 +1,96 @@
+package oxygen.http.schema.compat
+
+import oxygen.http.schema.compiled.RawCompiledApiSpec
+import oxygen.json.JsonCodec
+import oxygen.predef.json.*
+import oxygen.zio.error.FileSystemError
+import oxygen.zio.system.Path
+import scala.collection.immutable.ArraySeq
+import zio.*
+
+/**
+  * The "avro paradigm" harness for the compiled HTTP API spec -- the endpoint-schema analogue of
+  * `oxygen.sql.migration.MigrationCheck`. Diffs the current-code spec against the committed JSON file
+  * and either confirms it is up to date or (when permitted) writes the new spec.
+  *
+  *   - In CI (`allowUpdate = false`), a stale/absent committed spec yields [[Outcome.PendingUpdate]] --
+  *     the caller fails the build, signalling the committed doc is out of date.
+  *   - Locally (`allowUpdate = true`), the new spec is written. A change that is *incompatible* for
+  *     clients additionally requires `allowIncompatible = true`, else [[Outcome.BlockedIncompatible]].
+  */
+object HttpApiSpecCheck {
+
+  final case class Config(allowUpdate: Boolean, allowIncompatible: Boolean)
+  object Config {
+
+    val allowUpdateEnv: String = "OXYGEN_HTTP_ALLOW_UPDATE"
+    val allowIncompatibleEnv: String = "OXYGEN_HTTP_ALLOW_INCOMPATIBLE"
+
+    /** CI default: never write, never allow incompatible. */
+    val ci: Config = Config(allowUpdate = false, allowIncompatible = false)
+
+    private def truthy(value: Option[String]): Boolean =
+      value.map(_.trim.toLowerCase).exists(v => v == "true" || v == "1" || v == "yes")
+
+    val fromEnv: ZIO[Any, SecurityException, Config] =
+      for {
+        update <- System.env(allowUpdateEnv)
+        incompatible <- System.env(allowIncompatibleEnv)
+      } yield Config(truthy(update), truthy(incompatible))
+
+  }
+
+  enum Outcome {
+    case UpToDate
+    case Wrote(path: Path)
+    case PendingUpdate(comparison: HttpApiSpecComparison.Result)
+    case BlockedIncompatible(comparison: HttpApiSpecComparison.Result)
+  }
+
+  enum HttpApiSpecCheckError {
+    case Fs(cause: FileSystemError)
+    case Decode(fileName: String, message: String)
+  }
+
+  private val codec: JsonCodec[RawCompiledApiSpec] = JsonCodec[RawCompiledApiSpec]
+
+  private def canonical(spec: RawCompiledApiSpec): String = codec.encoder.encodeJsonStringCompact(spec.withoutLineNos)
+
+  def check(
+      path: Path,
+      currentSpec: RawCompiledApiSpec,
+      config: Config,
+  ): IO[HttpApiSpecCheckError, Outcome] = {
+    val current: RawCompiledApiSpec = currentSpec.withoutLineNos
+    path.exists.mapError(HttpApiSpecCheckError.Fs(_)).flatMap {
+      case false =>
+        // Genesis: nothing committed yet -- a new file is always compatible.
+        onDifference(path, current, HttpApiSpecComparison.Result(ArraySeq.empty), config)
+      case true =>
+        for {
+          contents <- path.read.mapError(HttpApiSpecCheckError.Fs(_))
+          committed <- ZIO.fromEither(contents.fromJsonString[RawCompiledApiSpec]).mapError(e => HttpApiSpecCheckError.Decode(path.fileName.name, e.getMessage))
+          outcome <-
+            if canonical(committed) == canonical(current) then ZIO.succeed(Outcome.UpToDate)
+            else onDifference(path, current, HttpApiSpecComparison.compare(committed.withoutLineNos, current), config)
+        } yield outcome
+    }
+  }
+
+  private def onDifference(
+      path: Path,
+      current: RawCompiledApiSpec,
+      comparison: HttpApiSpecComparison.Result,
+      config: Config,
+  ): IO[HttpApiSpecCheckError, Outcome] =
+    if !config.allowUpdate then ZIO.succeed(Outcome.PendingUpdate(comparison))
+    else if comparison.compatibility == HttpApiSpecComparison.Compatibility.Incompatible && !config.allowIncompatible then ZIO.succeed(Outcome.BlockedIncompatible(comparison))
+    else write(path, current).mapBoth(HttpApiSpecCheckError.Fs(_), _ => Outcome.Wrote(path))
+
+  private def write(path: Path, spec: RawCompiledApiSpec): IO[FileSystemError, Path] =
+    for {
+      _ <- path.parentOption.fold[IO[FileSystemError, Unit]](ZIO.unit)(_.createDirectories)
+      _ <- path.write(spec.toJsonStringPretty)
+    } yield path
+
+}

--- a/modules/http/zio/src/main/scala/oxygen/http/schema/compat/HttpApiSpecComparison.scala
+++ b/modules/http/zio/src/main/scala/oxygen/http/schema/compat/HttpApiSpecComparison.scala
@@ -1,0 +1,300 @@
+package oxygen.http.schema.compat
+
+import oxygen.http.schema.compiled.*
+import oxygen.predef.core.*
+import oxygen.schema.compiled.{CompiledSchemaRef, FullCompiledJsonSchema, FullCompiledPlainSchema, FullCompiledSchema, FullCompiledSchemas}
+import scala.collection.immutable.ArraySeq
+
+/**
+  * Endpoint/API-layer compatibility comparison for the compiled HTTP spec. Diffs two
+  * [[RawCompiledApiSpec]]s (an old committed spec vs the current-code spec) and collapses the structural
+  * difference to the binary gate the CI check needs, retaining a list of human-readable breaking changes
+  * for the failure message.
+  *
+  * The one non-obvious rule (from the ticket): **request and response compatibility are opposites.** A
+  * request is written by the (old) client and read by the (new) server, so it is compatible iff the new
+  * server accepts a superset of what the old client could send. A response is the mirror image -- written
+  * by the new server, read by the old client -- so every structural rule (added/removed field, required
+  * vs optional, nullable, added/removed sum case) flips. Both directions are derived from one
+  * [[Dir]]-parameterised set of rules, so they can never drift out of sync.
+  *
+  * Note: this resolves each side's schema refs against **its own** compiled-schema bundle and walks the
+  * structure directly, rather than delegating to `oxygen.schema.compat` -- whose comparison assumes both
+  * refs live in a single bundle and so cannot compare two independently-compiled specs where a type keeps
+  * its name but changes in place (exactly the common case here). The per-type-shape verdicts mirror that
+  * engine's; unhandled/mismatched shapes fall back to structural equality (never a false "compatible").
+  */
+object HttpApiSpecComparison {
+
+  enum Compatibility {
+    case Compatible
+    case Incompatible
+  }
+
+  /** One breaking change, located for an actionable failure message. */
+  final case class BreakingChange(location: String, detail: String)
+
+  final case class Result(breakingChanges: ArraySeq[BreakingChange]) {
+
+    def isCompatible: Boolean = breakingChanges.isEmpty
+
+    def compatibility: Compatibility = if isCompatible then Compatibility.Compatible else Compatibility.Incompatible
+
+    def describe: String =
+      if breakingChanges.isEmpty then "(no breaking changes)"
+      else breakingChanges.map(c => s"  - [${c.location}] ${c.detail}").mkString("\n")
+
+  }
+
+  /** Diff `from` (old / committed) against `to` (new / current-code). */
+  def compare(from: RawCompiledApiSpec, to: RawCompiledApiSpec): Result = {
+    given ctx: Ctx = Ctx(from.toFullCompiledApiSpec.schemas, to.toFullCompiledApiSpec.schemas)
+    Result(ArraySeq.from(diffApis(from.apis, to.apis)))
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////////
+  //      Internal -- direction + resolved-schema context
+  //////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  private enum Dir {
+    case Request
+    case Response
+  }
+
+  private final case class Ctx(fromSchemas: FullCompiledSchemas, toSchemas: FullCompiledSchemas)
+
+  private def refCompatible(dir: Dir, fromRef: CompiledSchemaRef, toRef: CompiledSchemaRef)(using ctx: Ctx): Boolean =
+    compatSchema(dir, ctx.fromSchemas.resolve(fromRef), ctx.toSchemas.resolve(toRef), Set.empty)
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////////
+  //      Internal -- structural schema comparison (reader-accepts-superset for requests; mirrored for responses)
+  //////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  private def compatSchema(dir: Dir, from: FullCompiledSchema, to: FullCompiledSchema, seen: Set[(CompiledSchemaRef, CompiledSchemaRef)]): Boolean = {
+    val key: (CompiledSchemaRef, CompiledSchemaRef) = (from.ref, to.ref)
+    if seen.contains(key) then true // a recursive back-edge -- its verdict is decided where it was first entered
+    else compatSchemaChecked(dir, from, to, seen + key)
+  }
+
+  private def compatSchemaChecked(dir: Dir, from: FullCompiledSchema, to: FullCompiledSchema, seen: Set[(CompiledSchemaRef, CompiledSchemaRef)]): Boolean =
+    (from, to) match
+      case (f: FullCompiledJsonSchema.Transformed, _)                                     => compatSchema(dir, f.underlyingType.value, to, seen)
+      case (_, t: FullCompiledJsonSchema.Transformed)                                     => compatSchema(dir, from, t.underlyingType.value, seen)
+      case (f: FullCompiledPlainSchema.Transformed, _)                                    => compatSchema(dir, f.underlyingType.value, to, seen)
+      case (_, t: FullCompiledPlainSchema.Transformed)                                    => compatSchema(dir, from, t.underlyingType.value, seen)
+      case (f: FullCompiledJsonSchema.JsonProduct, t: FullCompiledJsonSchema.JsonProduct) => compatProduct(dir, f, t, seen)
+      case (f: FullCompiledJsonSchema.JsonSum, t: FullCompiledJsonSchema.JsonSum)         => compatSum(dir, f, t, seen)
+      case (f: FullCompiledJsonSchema.JsonArray, t: FullCompiledJsonSchema.JsonArray)     => compatSchema(dir, f.elemType.value, t.elemType.value, seen)
+      case (f: FullCompiledJsonSchema.JsonMap, t: FullCompiledJsonSchema.JsonMap)         =>
+        compatSchema(dir, f.keyType.value, t.keyType.value, seen) && compatSchema(dir, f.valueType.value, t.valueType.value, seen)
+      case (f: FullCompiledJsonSchema.JsonString, t: FullCompiledJsonSchema.JsonString) => compatSchema(dir, f.elemType.value, t.elemType.value, seen)
+      case (f: FullCompiledJsonSchema.JsonNumber, t: FullCompiledJsonSchema.JsonNumber) => f.numberFormat == t.numberFormat
+      case (f: FullCompiledJsonSchema.JsonAST, t: FullCompiledJsonSchema.JsonAST)       => f.jsonType == t.jsonType
+      case (f: FullCompiledPlainSchema.Enum, t: FullCompiledPlainSchema.Enum)           => compatEnum(dir, f, t)
+      case (_: FullCompiledPlainSchema.PlainText, _: FullCompiledPlainSchema.PlainText) => true
+      case _ => from.ref.showBase == to.ref.showBase // unhandled/mismatched shapes: compatible only if structurally identical
+
+  /////// Products ///////////////////////////////////////////////////////////////
+
+  private def fieldRequired(field: FullCompiledJsonSchema.ProductField): Boolean = field.onMissing.isEmpty
+
+  private def compatProduct(dir: Dir, from: FullCompiledJsonSchema.JsonProduct, to: FullCompiledJsonSchema.JsonProduct, seen: Set[(CompiledSchemaRef, CompiledSchemaRef)]): Boolean = {
+    val fromByName: Map[String, FullCompiledJsonSchema.ProductField] = from.fields.map(f => f.fieldName -> f).toMap
+    val toByName: Map[String, FullCompiledJsonSchema.ProductField] = to.fields.map(f => f.fieldName -> f).toMap
+    val addedOk: Boolean = to.fields.filterNot(f => fromByName.contains(f.fieldName)).forall(addedFieldOk(dir, _))
+    val removedOk: Boolean = from.fields.filterNot(f => toByName.contains(f.fieldName)).forall(removedFieldOk(dir, _))
+    val bothOk: Boolean = from.fields.forall(ff => toByName.get(ff.fieldName).forall(tf => bothFieldOk(dir, ff, tf, seen)))
+    addedOk && removedOk && bothOk
+  }
+
+  private def addedFieldOk(dir: Dir, field: FullCompiledJsonSchema.ProductField): Boolean =
+    dir match
+      case Dir.Request  => !fieldRequired(field) // adding a required request field is breaking
+      case Dir.Response => true // a new response field is ignorable by the old client
+
+  private def removedFieldOk(dir: Dir, field: FullCompiledJsonSchema.ProductField): Boolean =
+    dir match
+      case Dir.Request  => true // the server ignores a field the old client still sends
+      case Dir.Response => !fieldRequired(field) // removing a required response field breaks the old client
+
+  private def bothFieldOk(dir: Dir, from: FullCompiledJsonSchema.ProductField, to: FullCompiledJsonSchema.ProductField, seen: Set[(CompiledSchemaRef, CompiledSchemaRef)]): Boolean = {
+    val fromReq: Boolean = fieldRequired(from)
+    val toReq: Boolean = fieldRequired(to)
+    val presenceOk: Boolean =
+      dir match
+        case Dir.Request  => !(!fromReq && toReq) // optional -> required is breaking for requests
+        case Dir.Response => !(fromReq && !toReq) // required -> optional is breaking for responses
+    val nullableOk: Boolean =
+      dir match
+        case Dir.Request  => !(from.nullable && !to.nullable) // nullable -> non-nullable is breaking for requests
+        case Dir.Response => !(!from.nullable && to.nullable) // non-nullable -> nullable is breaking for responses
+    presenceOk && nullableOk && compatSchema(dir, from.fieldType.value, to.fieldType.value, seen)
+  }
+
+  /////// Sums ///////////////////////////////////////////////////////////////
+
+  private def compatSum(dir: Dir, from: FullCompiledJsonSchema.JsonSum, to: FullCompiledJsonSchema.JsonSum, seen: Set[(CompiledSchemaRef, CompiledSchemaRef)]): Boolean = {
+    val fromByName: Map[String, FullCompiledJsonSchema.SumCase] = from.cases.map(c => c.caseName -> c).toMap
+    val toByName: Map[String, FullCompiledJsonSchema.SumCase] = to.cases.map(c => c.caseName -> c).toMap
+    val added: Boolean = to.cases.forall(c => fromByName.contains(c.caseName))
+    val removed: Boolean = from.cases.forall(c => toByName.contains(c.caseName))
+    val addedOk: Boolean = dir match
+      case Dir.Request  => true // the old client never sends a newly-added case
+      case Dir.Response => added // a newly-added response case breaks the old client's decoder
+    val removedOk: Boolean = dir match
+      case Dir.Request  => removed // the old client may still send a removed case
+      case Dir.Response => true
+    val bothOk: Boolean = from.cases.forall(fc => toByName.get(fc.caseName).forall(tc => compatSchema(dir, fc.caseType.value, tc.caseType.value, seen)))
+    (from.discriminator == to.discriminator) && addedOk && removedOk && bothOk
+  }
+
+  /////// Enums ///////////////////////////////////////////////////////////////
+
+  private def compatEnum(dir: Dir, from: FullCompiledPlainSchema.Enum, to: FullCompiledPlainSchema.Enum): Boolean = {
+    val fromValues: Set[String] = from.values.toSet
+    val toValues: Set[String] = to.values.toSet
+    val setOk: Boolean = dir match
+      case Dir.Request  => (fromValues -- toValues).isEmpty // removing an accepted value breaks old requests
+      case Dir.Response => (toValues -- fromValues).isEmpty // adding an emitted value breaks the old client
+    (from.caseSensitive == to.caseSensitive) && (from.exhaustive == to.exhaustive) && setOk
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////////
+  //      Internal -- structural walk of the spec
+  //////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  private def apiLabel(name: Option[String]): String = name.getOrElse("<root>")
+  private def epLabel(apiName: Option[String], endpointName: String): String = s"${apiLabel(apiName)}.$endpointName"
+
+  private def diffApis(from: ArraySeq[RawCompiledApi], to: ArraySeq[RawCompiledApi])(using Ctx): Seq[BreakingChange] = {
+    val toByName: Map[Option[String], RawCompiledApi] = to.map(a => a.name -> a).toMap
+    val removed: Seq[BreakingChange] = from.filterNot(a => toByName.contains(a.name)).map(a => BreakingChange(apiLabel(a.name), "API removed"))
+    val matched: Seq[BreakingChange] = from.flatMap(fa => toByName.get(fa.name).toList.flatMap(ta => diffApi(fa, ta)))
+    removed ++ matched
+  }
+
+  private def diffApi(from: RawCompiledApi, to: RawCompiledApi)(using Ctx): Seq[BreakingChange] = {
+    val toByName: Map[String, RawCompiledEndpoint] = to.endpoints.map(e => e.name -> e).toMap
+    val removed: Seq[BreakingChange] = from.endpoints.filterNot(e => toByName.contains(e.name)).map(e => BreakingChange(epLabel(from.name, e.name), "endpoint removed"))
+    val matched: Seq[BreakingChange] = from.endpoints.flatMap(fe => toByName.get(fe.name).toList.flatMap(te => diffEndpoint(from.name, fe, te)))
+    removed ++ matched
+  }
+
+  private def diffEndpoint(apiName: Option[String], from: RawCompiledEndpoint, to: RawCompiledEndpoint)(using Ctx): Seq[BreakingChange] = {
+    val loc: String = epLabel(apiName, from.name)
+    diffRequest(loc, from.request, to.request) ++
+      diffResponse(s"$loc success-response", from.successResponse, to.successResponse) ++
+      diffResponse(s"$loc error-response", from.errorResponse, to.errorResponse)
+  }
+
+  /////// Request ///////////////////////////////////////////////////////////////
+
+  private def diffRequest(loc: String, from: RawCompiledRequest, to: RawCompiledRequest)(using Ctx): Seq[BreakingChange] = {
+    val methodChange: Seq[BreakingChange] =
+      if from.method == to.method then Nil
+      else Seq(BreakingChange(loc, s"request method changed ${from.method.fold("<any>")(_.name)} -> ${to.method.fold("<any>")(_.name)}"))
+    methodChange ++
+      diffPaths(loc, from.paths, to.paths) ++
+      diffParams(Dir.Request, s"$loc query", from.queryParams, to.queryParams) ++
+      diffParams(Dir.Request, s"$loc header", from.headers, to.headers) ++
+      diffRequestBody(loc, from.body, to.body)
+  }
+
+  private def pathSignature(paths: NonEmptyList[RawCompiledPaths]): List[String] =
+    paths.toList.map { p =>
+      val segs: String = p.segments.map {
+        case RawCompiledPathSegment.Const(c)       => s"/$c"
+        case RawCompiledPathSegment.Param(_, _, _) => "/{}"
+      }.mkString
+      segs + p.rest.fold("")(_ => "/{...}")
+    }
+
+  private def pathParamRefs(paths: NonEmptyList[RawCompiledPaths]): List[(String, CompiledSchemaRef)] =
+    paths.toList.flatMap { p =>
+      val singles: List[(String, CompiledSchemaRef)] = p.segments.toList.collect { case RawCompiledPathSegment.Param(n, _, ref) => (n, ref) }
+      singles ++ p.rest.toList.map(r => (r.name, r.schema))
+    }
+
+  private def diffPaths(loc: String, from: NonEmptyList[RawCompiledPaths], to: NonEmptyList[RawCompiledPaths])(using Ctx): Seq[BreakingChange] =
+    if pathSignature(from) != pathSignature(to) then Seq(BreakingChange(loc, "request path shape changed"))
+    else
+      pathParamRefs(from).zip(pathParamRefs(to)).flatMap { case ((n, fRef), (_, tRef)) =>
+        if refCompatible(Dir.Request, fRef, tRef) then Nil
+        else Seq(BreakingChange(s"$loc path '$n'", "incompatible path-param schema change"))
+      }
+
+  private def diffRequestBody(loc: String, from: RawCompiledRequestBody, to: RawCompiledRequestBody)(using Ctx): Seq[BreakingChange] =
+    (from, to) match
+      case (RawCompiledRequestBody.Empty, RawCompiledRequestBody.Empty)                           => Nil
+      case (RawCompiledRequestBody.Empty, RawCompiledRequestBody.Single(_, _, _))                 => Seq(BreakingChange(s"$loc body", "added a required request body"))
+      case (RawCompiledRequestBody.Single(_, _, _), RawCompiledRequestBody.Empty)                 => Nil // dropping a request body requirement is non-breaking for the server
+      case (RawCompiledRequestBody.Single(_, _, fRef), RawCompiledRequestBody.Single(_, _, tRef)) =>
+        if refCompatible(Dir.Request, fRef, tRef) then Nil
+        else Seq(BreakingChange(s"$loc body", "incompatible request body schema change"))
+
+  /////// Response ///////////////////////////////////////////////////////////////
+
+  private def diffResponse(loc: String, from: RawCompiledResponse, to: RawCompiledResponse)(using Ctx): Seq[BreakingChange] =
+    // status codes are deliberately de-emphasised in oxygen-http (decoding keys off body discriminators) -- not gated here.
+    diffParams(Dir.Response, s"$loc header", from.headers, to.headers) ++
+      diffResponseBody(loc, from.body, to.body)
+
+  private def diffResponseBody(loc: String, from: RawCompiledResponseBody, to: RawCompiledResponseBody)(using Ctx): Seq[BreakingChange] =
+    (from, to) match
+      case (RawCompiledResponseBody.Empty, RawCompiledResponseBody.Empty)                                   => Nil
+      case (RawCompiledResponseBody.Empty, _)                                                               => Nil // the client can ignore a newly-present response body
+      case (_, RawCompiledResponseBody.Empty)                                                               => Seq(BreakingChange(s"$loc body", "removed the response body"))
+      case (RawCompiledResponseBody.Single(fRef), RawCompiledResponseBody.Single(tRef))                     => respBodySchema(loc, fRef, tRef)
+      case (RawCompiledResponseBody.ServerSentEvents(fRef), RawCompiledResponseBody.ServerSentEvents(tRef)) => respBodySchema(loc, fRef, tRef)
+      case (RawCompiledResponseBody.LineStream(fRef), RawCompiledResponseBody.LineStream(tRef))             => respBodySchema(loc, fRef, tRef)
+      case (_, _)                                                                                           => Seq(BreakingChange(s"$loc body", "response body kind changed"))
+
+  private def respBodySchema(loc: String, fromRef: CompiledSchemaRef, toRef: CompiledSchemaRef)(using Ctx): Seq[BreakingChange] =
+    if refCompatible(Dir.Response, fromRef, toRef) then Nil
+    else Seq(BreakingChange(s"$loc body", "incompatible response body schema change"))
+
+  /////// Params (query / header) ///////////////////////////////////////////////////////////////
+
+  private def paramRequired(kind: CompiledParamType): Boolean =
+    kind match
+      case CompiledParamType.Required | CompiledParamType.ManyRequired => true
+      case CompiledParamType.Optional | CompiledParamType.ManyOptional => false
+
+  private def paramMany(kind: CompiledParamType): Boolean =
+    kind match
+      case CompiledParamType.ManyRequired | CompiledParamType.ManyOptional => true
+      case CompiledParamType.Required | CompiledParamType.Optional         => false
+
+  private def diffParams(dir: Dir, loc: String, from: ArraySeq[RawCompiledParam], to: ArraySeq[RawCompiledParam])(using Ctx): Seq[BreakingChange] = {
+    val fromByName: Map[String, RawCompiledParam] = from.map(p => p.name -> p).toMap
+    val toByName: Map[String, RawCompiledParam] = to.map(p => p.name -> p).toMap
+    val added: Seq[BreakingChange] = to.filterNot(p => fromByName.contains(p.name)).flatMap(p => addedParam(dir, loc, p))
+    val removed: Seq[BreakingChange] = from.filterNot(p => toByName.contains(p.name)).flatMap(p => removedParam(dir, loc, p))
+    val both: Seq[BreakingChange] = from.flatMap(fp => toByName.get(fp.name).toList.flatMap(tp => bothParam(dir, loc, fp, tp)))
+    added ++ removed ++ both
+  }
+
+  private def addedParam(dir: Dir, loc: String, param: RawCompiledParam): Seq[BreakingChange] =
+    dir match
+      case Dir.Request  => if paramRequired(param.kind) then Seq(BreakingChange(s"$loc '${param.name}'", "added a required param")) else Nil
+      case Dir.Response => Nil // a new response value is ignorable by the old client
+
+  private def removedParam(dir: Dir, loc: String, param: RawCompiledParam): Seq[BreakingChange] =
+    dir match
+      case Dir.Request  => Nil // the server ignores a param the old client still sends
+      case Dir.Response => if paramRequired(param.kind) then Seq(BreakingChange(s"$loc '${param.name}'", "removed a required response value")) else Nil
+
+  private def bothParam(dir: Dir, loc: String, from: RawCompiledParam, to: RawCompiledParam)(using Ctx): Seq[BreakingChange] = {
+    val where: String = s"$loc '${from.name}'"
+    val cardinalityChange: Seq[BreakingChange] =
+      if paramMany(from.kind) != paramMany(to.kind) then Seq(BreakingChange(where, "param cardinality changed (single <-> many)")) else Nil
+    val requiredChange: Seq[BreakingChange] =
+      dir match
+        case Dir.Request  => if !paramRequired(from.kind) && paramRequired(to.kind) then Seq(BreakingChange(where, "param became required")) else Nil
+        case Dir.Response => if paramRequired(from.kind) && !paramRequired(to.kind) then Seq(BreakingChange(where, "response value became optional")) else Nil
+    val schemaChange: Seq[BreakingChange] =
+      if refCompatible(dir, from.schema, to.schema) then Nil else Seq(BreakingChange(where, "incompatible param schema change"))
+    cardinalityChange ++ requiredChange ++ schemaChange
+  }
+
+}


### PR DESCRIPTION
Phase 4 of the http-docs feature: persist the compiled HTTP API spec and fail CI on breaking changes, the endpoint-schema analogue of SQL's `MigrationCheck` + `DbMigrationSpec`.

## What landed
- **`oxygen.http.schema.compat.HttpApiSpecComparison.compare(from, to)`** (shared) — diffs two `RawCompiledApiSpec`s into a binary gate (`Compatible`/`Incompatible`) plus located `BreakingChange`s. Implements the ticket's headline rule that **request and response compatibility are exact opposites** (add-required-field is breaking for requests, non-breaking for responses; sum add/remove case flips; etc.) from one `Dir`-parameterised rule set, so the two directions can't drift.
  - It resolves each side against **its own** compiled-schema bundle and walks the structure directly, because `oxygen.schema.compat`'s comparison resolves both refs from a single bundle (`eval(full, full)`) and so can't compare two independently-compiled specs where a type keeps its name and changes in place (the common case here); its `ByName`/`Full` ctors are `private[schema]`, so external namespacing isn't possible either. Per-shape verdicts mirror that engine; unhandled/mismatched shapes fall back to structural equality (never a false "compatible"). A future two-bundle `compare` (OXY-29 / OFF-369) could replace the walk.
- **`HttpApiSpecCheck`** (`.jvm`) — persist + diff + env-gated update, mirroring `MigrationCheck`: `Config(allowUpdate, allowIncompatible)` + `fromEnv` (`OXYGEN_HTTP_ALLOW_UPDATE` / `OXYGEN_HTTP_ALLOW_INCOMPATIBLE`) + `Outcome` (`UpToDate`/`Wrote`/`PendingUpdate`/`BlockedIncompatible`) + `check(path, currentSpec, config)`.
- **New `oxygen-http-test` module** with the reusable **`ApiSpecCompatibilitySpec`** base (mirrors `DbMigrationSpec`, `@@ withLiveEnvironment`); `http-it` now depends on it.
- **Tests** in `http-it`: both compatibility tables (request vs response opposite, incl. sum cases) and the harness over temp files. Updated the Phase 4 plan doc.

## Verification
- `sbt oxygen-httpJS/compile` (shared code cross-compiles JVM+JS), `http-it/Test/compile`, `scalafmtAll`/`scalafmtSbt` clean.
- 16 tests green (`HttpApiSpecComparisonSpec` + `HttpApiSpecCheckSpec`).

## Deferred (follow-ups)
- History-of-docs snapshots (the seed marked it optional); example-app wiring + a committed initial `oxygen-http-api-spec.json`; a two-bundle `oxygen.schema.compat.compare` (OXY-29 / OFF-369).

Jira: OFF-352